### PR TITLE
separating concerns of PK and UK

### DIFF
--- a/console/src/components/Services/Data/TableModify/ColumnEditor.js
+++ b/console/src/components/Services/Data/TableModify/ColumnEditor.js
@@ -166,7 +166,12 @@ const ColumnEditor = ({
           <div className="col-xs-6">
             <select
               className="input-sm form-control"
-              value={selectedProperties[colName].isUnique}
+              value={
+                !!(
+                  selectedProperties[colName].isUnique ||
+                  columnProperties.isOnlyPrimaryKey
+                )
+              }
               onChange={toggleColumnUnique}
               disabled={columnProperties.pkConstraint}
               data-test="edit-col-unique"

--- a/console/src/components/Services/Data/TableModify/ColumnEditorList.js
+++ b/console/src/components/Services/Data/TableModify/ColumnEditorList.js
@@ -70,7 +70,6 @@ const ColumnEditorList = ({
       isNullable: col.is_nullable === 'YES',
       isIdentity: col.is_identity === 'YES',
       pkConstraint: columnPKConstraints[colName],
-      pkLength,
       isUnique: isColumnUnique(tableSchema, colName),
       // uniqueConstraint: columnUniqueConstraints[colName],
       default: col.column_default || '',

--- a/console/src/components/Services/Data/TableModify/ColumnEditorList.js
+++ b/console/src/components/Services/Data/TableModify/ColumnEditorList.js
@@ -8,6 +8,7 @@ import {
   setColumnEdit,
   resetColumnEdit,
   editColumn,
+  isColumnUnique,
 } from '../TableModify/ModifyActions';
 import { ordinalColSort } from '../utils';
 import { defaultDataTypeToCast } from '../constants';
@@ -69,15 +70,13 @@ const ColumnEditorList = ({
       isNullable: col.is_nullable === 'YES',
       isIdentity: col.is_identity === 'YES',
       pkConstraint: columnPKConstraints[colName],
-      isUnique:
-        (columnPKConstraints[colName] && pkLength === 1) ||
-        columnUniqueConstraints[colName]
-          ? true
-          : false,
+      pkLength,
+      isUnique: isColumnUnique(tableSchema, colName),
       // uniqueConstraint: columnUniqueConstraints[colName],
       default: col.column_default || '',
       comment: col.comment || '',
       customFieldName: customColumnNames[colName] || '',
+      isOnlyPrimaryKey: columnPKConstraints[colName] && pkLength === 1,
     };
 
     const onSubmit = toggleEditor => {
@@ -116,7 +115,7 @@ const ColumnEditorList = ({
         propertiesList.push('primary key');
       }
 
-      if (columnProperties.isUnique) {
+      if (columnProperties.isUnique || columnProperties.isOnlyPrimaryKey) {
         propertiesList.push('unique');
       }
 

--- a/console/src/components/Services/Data/TableModify/ModifyActions.js
+++ b/console/src/components/Services/Data/TableModify/ModifyActions.js
@@ -1438,18 +1438,12 @@ const saveTableCommentSql = isTable => {
 };
 
 const isColumnUnique = (tableSchema, colName) => {
-  const { primary_key, unique_constraints } = tableSchema;
-
-  const columnPkConstraint =
-    primary_key.columns.includes(colName) && primary_key.columns.length === 1;
-
-  const columnUniqueConstraint =
-    unique_constraints.filter(
+  return (
+    tableSchema.unique_constraints.filter(
       constraint =>
         constraint.columns.includes(colName) && constraint.columns.length === 1
-    ).length > 0;
-
-  return columnPkConstraint || columnUniqueConstraint;
+    ).length > 0
+  );
 };
 
 const saveColumnChangesSql = (colName, column, onSuccess) => {


### PR DESCRIPTION
1. Keeps unique constraints and PK constraints separate
2. Fixes the unnecessary migrations issue (for good)
3. UX stays the same. PK is still shown to be unique, but without changing any logic in migration generation.