### PR TITLE
some new refactors

### DIFF
--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  TableDefinition,
-  getSelectQuery,
-  OrderBy,
-  makeOrderBy,
-} from '../utils/v1QueryUtils';
+import { getSelectQuery, OrderBy, makeOrderBy } from '../utils/v1QueryUtils';
 import requestAction from '../../../utils/requestAction';
 import { Dispatch } from '../../../types';
 import endpoints from '../../../Endpoints';
@@ -20,6 +15,7 @@ import {
 import { Nullable } from '../utils/tsUtils';
 import { isNotDefined } from '../utils/jsUtils';
 import { parseFilter } from './utils';
+import { QualifiedTable } from '../../../metadata/types';
 
 const defaultFilter = makeValueFilter('', null, '');
 const defaultSort = makeOrderBy('', 'asc');
@@ -27,7 +23,7 @@ const defaultSort = makeOrderBy('', 'asc');
 const defaultState = makeFilterState([defaultFilter], [defaultSort], 10, 0);
 
 export const useFilterQuery = (
-  table: TableDefinition,
+  table: QualifiedTable,
   dispatch: Dispatch,
   presets: {
     filters: Filter[];

--- a/console/src/components/Common/Headers/utils.ts
+++ b/console/src/components/Common/Headers/utils.ts
@@ -1,11 +1,11 @@
 import { Header as HeaderClient, defaultHeader } from './Headers';
-import { Header as HeaderServer } from '../utils/v1QueryUtils';
+import { ServerHeader } from '../../../metadata/types';
 
 export const transformHeaders = (headers_?: HeaderClient[]) => {
   const headers = headers_ || [];
   return headers
     .map(h => {
-      const transformedHeader: HeaderServer = {
+      const transformedHeader: ServerHeader = {
         name: h.name,
       };
       if (h.type === 'static') {
@@ -30,7 +30,7 @@ export const addPlaceholderHeader = (newHeaders: HeaderClient[]) => {
   return newHeaders;
 };
 
-export const parseServerHeaders = (headers: HeaderServer[] = []) => {
+export const parseServerHeaders = (headers: ServerHeader[] = []) => {
   return addPlaceholderHeader(
     headers.map(h => {
       const parsedHeader: HeaderClient = {

--- a/console/src/components/Common/utils/v1QueryUtils.ts
+++ b/console/src/components/Common/utils/v1QueryUtils.ts
@@ -1,14 +1,6 @@
-import { LocalScheduledTriggerState } from '../../Services/Events/CronTriggers/state';
-import { LocalAdhocEventState } from '../../Services/Events/AdhocEvents/Add/state';
-import { LocalEventTriggerState } from '../../Services/Events/EventTriggers/state';
-import { RemoteRelationshipPayload } from '../../Services/Data/TableRelationships/RemoteRelationships/utils';
-import { transformHeaders } from '../Headers/utils';
 import { Nullable } from './tsUtils';
-import { generateTableDef, terminateSql } from '../../../dataSources';
-
-// TODO add type for the where clause
-
-// TODO extend all queries with v1 query type
+import { generateTableDef } from '../../../dataSources';
+import { QualifiedTable } from '../../../metadata/types';
 
 export type OrderByType = 'asc' | 'desc';
 export type OrderByNulls = 'first' | 'last';
@@ -18,6 +10,25 @@ export type OrderBy = {
   type: OrderByType;
   nulls: Nullable<OrderByNulls>;
 };
+
+type validOperators =
+  | '$eq'
+  | '$ne'
+  | '$in'
+  | '$nin'
+  | '$gt'
+  | '$lt'
+  | '$gte'
+  | '$lte';
+type AndExp = Record<'$and', BoolExp[]>;
+type OrExp = Record<'$or', BoolExp[]>;
+type NotExp = Record<'$not', BoolExp[]>;
+type ColumnExpValue = Record<validOperators | string, any>;
+type ColumnExp = Record<string, ColumnExpValue>;
+type BoolExp = AndExp | OrExp | NotExp | ColumnExp;
+
+export type WhereClause = BoolExp | Record<string, any>;
+
 export const makeOrderBy = (
   column: string,
   type: OrderByType,
@@ -27,296 +38,6 @@ export const makeOrderBy = (
   type,
   nulls,
 });
-
-export type WhereClause = any;
-
-export type TableDefinition = {
-  name: string;
-  schema: string;
-};
-
-export type FunctionDefinition = {
-  name: string;
-  schema: string;
-};
-
-type GraphQLArgument = {
-  name: string;
-  type: string;
-  description: string;
-};
-
-export type Header = {
-  name: string;
-  value?: string;
-  value_from_env?: string;
-};
-
-export const getRunSqlQuery = (
-  sql: string,
-  shouldCascade?: boolean,
-  readOnly?: boolean
-) => {
-  return {
-    type: 'run_sql',
-    args: {
-      sql: terminateSql(sql),
-      cascade: !!shouldCascade,
-      read_only: !!readOnly,
-    },
-  };
-};
-
-export const getCreatePermissionQuery = (
-  action: string,
-  tableDef: TableDefinition,
-  role: string,
-  permission: any
-) => {
-  return {
-    type: `create_${action}_permission`,
-    args: {
-      table: tableDef,
-      role,
-      permission,
-    },
-  };
-};
-
-export const getDropPermissionQuery = (
-  action: string,
-  tableDef: TableDefinition,
-  role: string
-) => {
-  return {
-    type: `drop_${action}_permission`,
-    args: {
-      table: tableDef,
-      role,
-    },
-  };
-};
-
-type CustomTypeScalar = {
-  name: string;
-  description: string;
-};
-
-type CustomTypeEnumValue = {
-  value: string;
-  description: string;
-};
-type CustomTypeEnum = {
-  name: string;
-  values: CustomTypeEnumValue[];
-  description: string;
-};
-
-type CustomTypeObjectField = {
-  name: string;
-  type: string;
-  description: string;
-};
-type CustomTypeObject = {
-  name: string;
-  description: string;
-  fields: CustomTypeObjectField[];
-};
-
-type CustomTypeInputObjectField = {
-  name: string;
-  type: string;
-  description: string;
-};
-type CustomTypeInputObject = {
-  name: string;
-  description: string;
-  fields: CustomTypeInputObjectField[];
-};
-
-type CustomTypes = {
-  scalars: CustomTypeScalar[];
-  enums: CustomTypeEnum[];
-  objects: CustomTypeObject[];
-  input_objects: CustomTypeInputObject[];
-};
-
-export const generateSetCustomTypesQuery = (customTypes: CustomTypes) => {
-  return {
-    type: 'set_custom_types',
-    args: customTypes,
-  };
-};
-
-type ActionDefinition = {
-  arguments: GraphQLArgument[];
-  kind: 'synchronous' | 'asynchronous';
-  output_type: string;
-  handler: string;
-  headers: Header[];
-  forward_client_headers: boolean;
-};
-
-export const generateCreateActionQuery = (
-  name: string,
-  definition: ActionDefinition,
-  comment: string
-) => {
-  return {
-    type: 'create_action',
-    args: {
-      name,
-      definition,
-      comment,
-    },
-  };
-};
-
-export const generateDropActionQuery = (name: string) => {
-  return {
-    type: 'drop_action',
-    args: {
-      name,
-    },
-  };
-};
-
-type CustomRootFields = {
-  select: string;
-  select_by_pk: string;
-  select_aggregate: string;
-  insert: string;
-  update: string;
-  delete: string;
-};
-
-type CustomColumnNames = {
-  [columnName: string]: string;
-};
-
-export const getSetCustomRootFieldsQuery = (
-  tableDef: TableDefinition,
-  rootFields: CustomRootFields,
-  customColumnNames: CustomColumnNames
-) => {
-  return {
-    type: 'set_table_custom_fields',
-    version: 2,
-    args: {
-      table: tableDef,
-      custom_root_fields: rootFields,
-      custom_column_names: customColumnNames,
-    },
-  };
-};
-
-// TODO Refactor and accept role, filter and action name
-export const getCreateActionPermissionQuery = (
-  def: { role: string; filter: any },
-  actionName: string
-) => {
-  return {
-    type: 'create_action_permission',
-    args: {
-      action: actionName,
-      role: def.role,
-      definition: {
-        select: {
-          filter: def.filter,
-        },
-      },
-    },
-  };
-};
-
-export const getUpdateActionQuery = (
-  def: ActionDefinition,
-  actionName: string,
-  actionComment: string
-) => {
-  return {
-    type: 'update_action',
-    args: {
-      name: actionName,
-      definition: def,
-      comment: actionComment,
-    },
-  };
-};
-
-export const getDropActionPermissionQuery = (
-  role: string,
-  actionName: string
-) => {
-  return {
-    type: 'drop_action_permission',
-    args: {
-      action: actionName,
-      role,
-    },
-  };
-};
-
-export const getSetTableEnumQuery = (
-  tableDef: TableDefinition,
-  isEnum: boolean
-) => {
-  return {
-    type: 'set_table_is_enum',
-    args: {
-      table: tableDef,
-      is_enum: isEnum,
-    },
-  };
-};
-
-export const getTrackTableQuery = (tableDef: TableDefinition) => {
-  return {
-    type: 'add_existing_table_or_view',
-    args: tableDef,
-  };
-};
-
-export const getUntrackTableQuery = (tableDef: TableDefinition) => {
-  return {
-    type: 'untrack_table',
-    args: {
-      table: tableDef,
-    },
-  };
-};
-
-export const getAddComputedFieldQuery = (
-  tableDef: TableDefinition,
-  computedFieldName: string,
-  definition: any, // TODO
-  comment: string
-) => {
-  return {
-    type: 'add_computed_field',
-    args: {
-      table: tableDef,
-      name: computedFieldName,
-      definition: {
-        ...definition,
-      },
-      comment,
-    },
-  };
-};
-
-export const getDropComputedFieldQuery = (
-  tableDef: TableDefinition,
-  computedFieldName: string
-) => {
-  return {
-    type: 'drop_computed_field',
-    args: {
-      table: tableDef,
-      name: computedFieldName,
-    },
-  };
-};
 
 export const getDeleteQuery = (
   pkClause: WhereClause,
@@ -336,71 +57,24 @@ export const getDeleteQuery = (
 };
 
 export const getBulkDeleteQuery = (
-  pkClauses: WhereClause,
+  pkClauses: WhereClause[],
   tableName: string,
   schemaName: string
-) =>
-  pkClauses.map((pkClause: WhereClause) =>
-    getDeleteQuery(pkClause, tableName, schemaName)
-  );
+) => pkClauses.map(pkClause => getDeleteQuery(pkClause, tableName, schemaName));
 
 export const getEnumOptionsQuery = (
   request: { enumTableName: string; enumColumnName: string },
   currentSchema: string
-) => {
-  return {
-    type: 'select',
-    args: {
-      table: {
-        name: request.enumTableName,
-        schema: currentSchema,
-      },
-      columns: [request.enumColumnName],
-    },
-  };
-};
-
-export const inconsistentObjectsQuery = {
-  type: 'get_inconsistent_metadata',
-  args: {},
-};
-
-export const dropInconsistentObjectsQuery = {
-  type: 'drop_inconsistent_metadata',
-  args: {},
-};
-
-export const getReloadMetadataQuery = (shouldReloadRemoteSchemas: boolean) => ({
-  type: 'reload_metadata',
+) => ({
+  type: 'select',
   args: {
-    reload_remote_schemas: shouldReloadRemoteSchemas,
+    table: {
+      name: request.enumTableName,
+      schema: currentSchema,
+    },
+    columns: [request.enumColumnName],
   },
 });
-
-export const getReloadRemoteSchemaCacheQuery = (remoteSchemaName: string) => {
-  return {
-    type: 'reload_remote_schema',
-    args: {
-      name: remoteSchemaName,
-    },
-  };
-};
-
-export const exportMetadataQuery = {
-  type: 'export_metadata',
-  args: {},
-};
-
-// type the metadata
-export const generateReplaceMetadataQuery = (metadataJson: any) => ({
-  type: 'replace_metadata',
-  args: metadataJson,
-});
-
-export const resetMetadataQuery = {
-  type: 'clear_metadata',
-  args: {},
-};
 
 export const fetchEventTriggersQuery = {
   type: 'select',
@@ -410,7 +84,7 @@ export const fetchEventTriggersQuery = {
       schema: 'hdb_catalog',
     },
     columns: ['*'],
-    order_by: [{ column: 'name', type: 'asc' }],
+    order_by: [makeOrderBy('name', 'asc')],
   },
 };
 
@@ -422,120 +96,15 @@ export const fetchScheduledTriggersQuery = {
       schema: 'hdb_catalog',
     },
     columns: ['*'],
-    order_by: [{ column: 'name', type: 'asc' }],
+    order_by: [makeOrderBy('name', 'asc')],
   },
-};
-
-export const getBulkQuery = (args: any[]) => {
-  return {
-    type: 'bulk',
-    args,
-  };
-};
-
-export const generateCreateEventTriggerQuery = (
-  state: LocalEventTriggerState,
-  replace = false
-) => {
-  return {
-    type: 'create_event_trigger',
-    args: {
-      name: state.name.trim(),
-      table: state.table,
-      webhook:
-        state.webhook.type === 'static' ? state.webhook.value.trim() : null,
-      webhook_from_env:
-        state.webhook.type === 'env' ? state.webhook.value.trim() : null,
-      insert: state.operations.insert
-        ? {
-            columns: '*',
-          }
-        : null,
-      update: state.operations.update
-        ? {
-            columns: state.operationColumns
-              .filter(c => !!c.enabled)
-              .map(c => c.name),
-          }
-        : null,
-      delete: state.operations.delete
-        ? {
-            columns: '*',
-          }
-        : null,
-      enable_manual: state.operations.enable_manual,
-      retry_conf: state.retryConf,
-      headers: transformHeaders(state.headers),
-      replace,
-    },
-  };
-};
-
-export const getDropEventTriggerQuery = (name: string) => ({
-  type: 'delete_event_trigger',
-  args: {
-    name: name.trim(),
-  },
-});
-
-export const generateCreateScheduledTriggerQuery = (
-  state: LocalScheduledTriggerState,
-  replace = false
-) => ({
-  type: 'create_cron_trigger',
-  args: {
-    name: state.name.trim(),
-    webhook: state.webhook,
-    schedule: state.schedule,
-    payload: JSON.parse(state.payload),
-    headers: transformHeaders(state.headers),
-    retry_conf: {
-      num_retries: state.retryConf.num_retries,
-      retry_interval_seconds: state.retryConf.interval_sec,
-      timeout_seconds: state.retryConf.timeout_sec,
-      tolerance_seconds: state.retryConf.tolerance_sec,
-    },
-    comment: state.comment,
-    include_in_metadata: state.includeInMetadata,
-    replace,
-  },
-});
-
-export const generateUpdateScheduledTriggerQuery = (
-  state: LocalScheduledTriggerState
-) => generateCreateScheduledTriggerQuery(state, true);
-
-export const getDropScheduledTriggerQuery = (name: string) => ({
-  type: 'delete_cron_trigger',
-  args: {
-    name: name.trim(),
-  },
-});
-
-export const getCreateScheduledEventQuery = (state: LocalAdhocEventState) => {
-  return {
-    type: 'create_scheduled_event',
-    args: {
-      webhook: state.webhook,
-      schedule_at: state.time.toISOString(),
-      headers: transformHeaders(state.headers),
-      retry_conf: {
-        num_retries: state.retryConf.num_retries,
-        retry_interval_seconds: state.retryConf.interval_sec,
-        timeout_seconds: state.retryConf.timeout_sec,
-        tolerance_seconds: state.retryConf.tolerance_sec,
-      },
-      payload: state.payload,
-      comment: state.comment,
-    },
-  };
 };
 
 export type SelectColumn = string | { name: string; columns: SelectColumn[] };
 
 export const getSelectQuery = (
   type: 'select' | 'count',
-  table: TableDefinition,
+  table: QualifiedTable,
   columns: SelectColumn[],
   where: Nullable<WhereClause>,
   offset: Nullable<number>,
@@ -574,7 +143,7 @@ export const getFetchInvocationLogsQuery = (
 
 export type SelectQueryGenerator = typeof getFetchInvocationLogsQuery;
 
-export const getFetchManualTriggersQuery = (tableDef: TableDefinition) =>
+export const getFetchManualTriggersQuery = (tableDef: QualifiedTable) =>
   getSelectQuery(
     'select',
     generateTableDef('event_triggers', 'hdb_catalog'),
@@ -593,41 +162,6 @@ export const getFetchManualTriggersQuery = (tableDef: TableDefinition) =>
       },
     ]
   );
-
-export const getRedeliverDataEventQuery = (eventId: string) => ({
-  type: 'redeliver_event',
-  args: {
-    event_id: eventId,
-  },
-});
-
-export const getSaveRemoteRelQuery = (
-  args: RemoteRelationshipPayload,
-  isNew: boolean
-) => ({
-  type: `${isNew ? 'create' : 'update'}_remote_relationship`,
-  args,
-});
-
-export const getDropRemoteRelQuery = (
-  name: string,
-  table: TableDefinition
-) => ({
-  type: 'delete_remote_relationship',
-  args: {
-    name,
-    table,
-  },
-});
-
-export const getRemoteSchemaIntrospectionQuery = (
-  remoteSchemaName: string
-) => ({
-  type: 'introspect_remote_schema',
-  args: {
-    name: remoteSchemaName,
-  },
-});
 
 export const getConsoleOptsQuery = () =>
   getSelectQuery(

--- a/console/src/components/Main/Actions.js
+++ b/console/src/components/Main/Actions.js
@@ -4,7 +4,7 @@ import requestAction from '../../utils/requestAction';
 import requestActionPlain from '../../utils/requestActionPlain';
 import Endpoints, { globalCookiePolicy } from '../../Endpoints';
 import { getFeaturesCompatibility } from '../../helpers/versionUtils';
-import { getRunSqlQuery } from '../Common/utils/v1QueryUtils';
+import { getRunSqlQuery } from '../../metadata/queryUtils';
 
 const SET_MIGRATION_STATUS_SUCCESS = 'Main/SET_MIGRATION_STATUS_SUCCESS';
 const SET_MIGRATION_STATUS_ERROR = 'Main/SET_MIGRATION_STATUS_ERROR';

--- a/console/src/components/Services/Actions/Permissions/utils.js
+++ b/console/src/components/Services/Actions/Permissions/utils.js
@@ -1,8 +1,8 @@
+import { findActionPermission } from '../utils';
 import {
   getCreateActionPermissionQuery,
   getDropActionPermissionQuery,
-} from '../../../Common/utils/v1QueryUtils';
-import { findActionPermission } from '../utils';
+} from '../../../../metadata/queryUtils';
 
 export const getActionPermissionQueries = (
   permissionEdit,

--- a/console/src/components/Services/Actions/ServerIO.js
+++ b/console/src/components/Services/Actions/ServerIO.js
@@ -1,14 +1,6 @@
 import globals from '../../../Globals';
 import { makeMigrationCall } from '../Data/DataActions';
 import {
-  generateSetCustomTypesQuery,
-  generateCreateActionQuery,
-  generateDropActionQuery,
-  getCreateActionPermissionQuery,
-  getDropActionPermissionQuery,
-  getUpdateActionQuery,
-} from '../../Common/utils/v1QueryUtils';
-import {
   injectTypeRelationship,
   removeTypeRelationship,
   validateRelTypename,
@@ -57,6 +49,14 @@ import {
   customTypesSelector,
   actionsSelector,
 } from '../../../metadata/selector';
+import {
+  generateSetCustomTypesQuery,
+  generateCreateActionQuery,
+  generateDropActionQuery,
+  getCreateActionPermissionQuery,
+  getUpdateActionQuery,
+  getDropActionPermissionQuery,
+} from '../../../metadata/queryUtils';
 
 export const createAction = () => (dispatch, getState) => {
   const { add: rawState } = getState().actions;

--- a/console/src/components/Services/Data/Add/AddActions.js
+++ b/console/src/components/Services/Data/Add/AddActions.js
@@ -8,10 +8,9 @@ import {
 } from '../../Common/Notification';
 import { UPDATE_MIGRATION_STATUS_ERROR } from '../../../Main/Actions';
 import { setTable } from '../DataActions.js';
-
-import { getRunSqlQuery } from '../../../Common/utils/v1QueryUtils';
 import { getTableModifyRoute } from '../../../Common/utils/routesUtils';
 import { dataSource } from '../../../../dataSources';
+import { getRunSqlQuery } from '../../../../metadata/queryUtils';
 
 const SET_DEFAULTS = 'AddTable/SET_DEFAULTS';
 const SET_TABLENAME = 'AddTable/SET_TABLENAME';

--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -2,7 +2,6 @@ import React from 'react';
 import sanitize from 'sanitize-filename';
 
 import { getSchemaBaseRoute } from '../../Common/utils/routesUtils';
-import { getRunSqlQuery } from '../../Common/utils/v1QueryUtils';
 import Endpoints, { globalCookiePolicy } from '../../../Endpoints';
 import requestAction from '../../../utils/requestAction';
 import defaultState from './DataState';
@@ -22,7 +21,6 @@ import { loadMigrationStatus } from '../../Main/Actions';
 import returnMigrateUrl from './Common/getMigrateUrl';
 import { filterInconsistentMetadataObjects } from '../Settings/utils';
 import globals from '../../../Globals';
-
 import {
   fetchTrackedTableFkQuery,
   fetchTableListQuery,
@@ -30,11 +28,8 @@ import {
   getDependencyError,
 } from './utils';
 import { mergeLoadSchemaData } from './mergeData';
-
 import _push from './push';
-
 import { convertArrayToJson } from './TableModify/utils';
-
 import { CLI_CONSOLE_MODE, SERVER_CONSOLE_MODE } from '../../../constants';
 import { isEmpty } from '../../Common/utils/jsUtils';
 import { dataSource } from '../../../dataSources';
@@ -44,6 +39,7 @@ import {
   checkFeatureSupport,
   READ_ONLY_RUN_SQL_QUERIES,
 } from '../../../helpers/versionUtils';
+import { getRunSqlQuery } from '../../../metadata/queryUtils';
 
 const SET_TABLE = 'Data/SET_TABLE';
 const LOAD_FUNCTIONS = 'Data/LOAD_FUNCTIONS';
@@ -164,6 +160,9 @@ const loadSchema = configOptions => {
           false,
           checkFeatureSupport(READ_ONLY_RUN_SQL_QUERIES) ? true : false
         ),
+        getRunSqlQuery(dataSource.primaryKeysInfoSql(configOptions)),
+        getRunSqlQuery(dataSource.uniqueKeysSql(configOptions)),
+        getRunSqlQuery(dataSource.checkConstraintsSql(configOptions)),
       ],
     };
 

--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -160,9 +160,6 @@ const loadSchema = configOptions => {
           false,
           checkFeatureSupport(READ_ONLY_RUN_SQL_QUERIES) ? true : false
         ),
-        getRunSqlQuery(dataSource.primaryKeysInfoSql(configOptions)),
-        getRunSqlQuery(dataSource.uniqueKeysSql(configOptions)),
-        getRunSqlQuery(dataSource.checkConstraintsSql(configOptions)),
       ],
     };
 

--- a/console/src/components/Services/Data/Function/customFunctionReducer.js
+++ b/console/src/components/Services/Data/Function/customFunctionReducer.js
@@ -18,9 +18,9 @@ import { showSuccessNotification } from '../../Common/Notification';
 
 import _push from '../push';
 import { getSchemaBaseRoute } from '../../../Common/utils/routesUtils';
-import { getRunSqlQuery } from '../../../Common/utils/v1QueryUtils';
 import { dataSource } from '../../../../dataSources';
 import { exportMetadata } from '../../../../metadata/actions';
+import { getRunSqlQuery } from '../../../../metadata/queryUtils';
 
 /* Constants */
 

--- a/console/src/components/Services/Data/RawSQL/Actions.js
+++ b/console/src/components/Services/Data/RawSQL/Actions.js
@@ -12,10 +12,10 @@ import {
 import { parseCreateSQL } from './utils';
 import dataHeaders from '../Common/Headers';
 import returnMigrateUrl from '../Common/getMigrateUrl';
-import { getRunSqlQuery } from '../../../Common/utils/v1QueryUtils';
 import requestAction from '../../../../utils/requestAction';
 import { dataSource } from '../../../../dataSources';
 import { exportMetadata } from '../../../../metadata/actions';
+import { getRunSqlQuery } from '../../../../metadata/queryUtils';
 
 const MAKING_REQUEST = 'RawSQL/MAKING_REQUEST';
 const SET_SQL = 'RawSQL/SET_SQL';

--- a/console/src/components/Services/Data/Schema/Actions.js
+++ b/console/src/components/Services/Data/Schema/Actions.js
@@ -2,8 +2,8 @@ import gqlPattern, { gqlSchemaErrorNotif } from '../Common/GraphQLValidation';
 import { showErrorNotification } from '../../Common/Notification';
 import { makeMigrationCall, fetchSchemaList } from '../DataActions';
 import { getConfirmation } from '../../../Common/utils/jsUtils';
-import { getRunSqlQuery } from '../../../Common/utils/v1QueryUtils';
 import { dataSource } from '../../../../dataSources';
+import { getRunSqlQuery } from '../../../../metadata/queryUtils';
 
 export const createNewSchema = (schemaName, successCb, errorCb) => {
   return (dispatch, getState) => {

--- a/console/src/components/Services/Data/TableBrowseRows/ViewActions.js
+++ b/console/src/components/Services/Data/TableBrowseRows/ViewActions.js
@@ -13,7 +13,6 @@ import {
   getSelectQuery,
   getFetchManualTriggersQuery,
   getDeleteQuery,
-  getRunSqlQuery,
 } from '../../../Common/utils/v1QueryUtils';
 import { COUNT_LIMIT } from '../constants';
 import {
@@ -21,6 +20,7 @@ import {
   dataSource,
   findTableFromRel,
 } from '../../../../dataSources';
+import { getRunSqlQuery } from '../../../../metadata/queryUtils';
 
 /* ****************** View actions *************/
 const V_SET_DEFAULTS = 'ViewTable/V_SET_DEFAULTS';

--- a/console/src/components/Services/Data/TableModify/ModifyActions.js
+++ b/console/src/components/Services/Data/TableModify/ModifyActions.js
@@ -37,15 +37,6 @@ import {
   dataSource,
 } from '../../../../dataSources';
 import {
-  getSetCustomRootFieldsQuery,
-  getRunSqlQuery,
-  getDropComputedFieldQuery,
-  getAddComputedFieldQuery,
-  getSetTableEnumQuery,
-  getUntrackTableQuery,
-  getTrackTableQuery,
-} from '../../../Common/utils/v1QueryUtils';
-import {
   convertArrayToJson,
   sanitiseRootFields,
   sanitiseColumnNames,
@@ -55,6 +46,15 @@ import {
   getTableModifyRoute,
 } from '../../../Common/utils/routesUtils';
 import { exportMetadata } from '../../../../metadata/actions';
+import {
+  getRunSqlQuery,
+  getSetTableEnumQuery,
+  getTrackTableQuery,
+  getUntrackTableQuery,
+  getAddComputedFieldQuery,
+  getDropComputedFieldQuery,
+  getSetCustomRootFieldsQuery,
+} from '../../../../metadata/queryUtils';
 
 const DELETE_PK_WARNING =
   'Without a primary key there is no way to uniquely identify a row of a table';

--- a/console/src/components/Services/Data/TablePermissions/Actions.js
+++ b/console/src/components/Services/Data/TablePermissions/Actions.js
@@ -8,12 +8,12 @@ import {
   getTablePermissions,
   generateTableDef,
 } from '../../../../dataSources';
+import { capitalize } from '../../../Common/utils/jsUtils';
+import { exportMetadata } from '../../../../metadata/actions';
 import {
   getCreatePermissionQuery,
   getDropPermissionQuery,
-} from '../../../Common/utils/v1QueryUtils';
-import { capitalize } from '../../../Common/utils/jsUtils';
-import { exportMetadata } from '../../../../metadata/actions';
+} from '../../../../metadata/queryUtils';
 
 export const PERM_OPEN_EDIT = 'ModifyTable/PERM_OPEN_EDIT';
 export const PERM_SET_FILTER_TYPE = 'ModifyTable/PERM_SET_FILTER_TYPE';

--- a/console/src/components/Services/Data/TableRelationships/Actions.js
+++ b/console/src/components/Services/Data/TableRelationships/Actions.js
@@ -3,16 +3,16 @@ import inflection from 'inflection';
 import { makeMigrationCall, updateSchemaInfo } from '../DataActions';
 import gqlPattern, { gqlRelErrorNotif } from '../Common/GraphQLValidation';
 import { showErrorNotification } from '../../Common/Notification';
-import {
-  getSaveRemoteRelQuery,
-  getDropRemoteRelQuery,
-} from '../../../Common/utils/v1QueryUtils';
 import { getConfirmation } from '../../../Common/utils/jsUtils';
 import suggestedRelationshipsRaw from './autoRelations';
 import {
   getRemoteRelPayload,
   parseRemoteRelationship,
 } from './RemoteRelationships/utils';
+import {
+  getSaveRemoteRelQuery,
+  getDropRemoteRelQuery,
+} from '../../../../metadata/queryUtils';
 
 export const SET_MANUAL_REL_ADD = 'ModifyTable/SET_MANUAL_REL_ADD';
 export const MANUAL_REL_SET_TYPE = 'ModifyTable/MANUAL_REL_SET_TYPE';

--- a/console/src/components/Services/Data/TableRelationships/RemoteRelationships/utils.ts
+++ b/console/src/components/Services/Data/TableRelationships/RemoteRelationships/utils.ts
@@ -17,7 +17,7 @@ import {
   isNumber,
 } from '../../../../Common/utils/jsUtils';
 import { getUnderlyingType } from '../../../../../shared/utils/graphqlSchemaUtils';
-import { TableDefinition } from '../../../../Common/utils/v1QueryUtils';
+import { QualifiedTable } from '../../../../../metadata/types';
 
 export type ArgValueKind = 'column' | 'static';
 export type ArgValue = {
@@ -270,7 +270,7 @@ export type RemoteRelationshipPayload = {
   remote_schema: string;
   remote_field: Record<string, RemoteRelationshipFieldServer>;
   hasura_fields: string[];
-  table: TableDefinition;
+  table: QualifiedTable;
 };
 
 export const getRemoteRelPayload = (

--- a/console/src/components/Services/Data/utils.js
+++ b/console/src/components/Services/Data/utils.js
@@ -2,10 +2,10 @@ import {
   READ_ONLY_RUN_SQL_QUERIES,
   checkFeatureSupport,
 } from '../../../helpers/versionUtils';
-import { getRunSqlQuery } from '../../Common/utils/v1QueryUtils';
 import { isJsonString } from '../../Common/utils/jsUtils';
 import { ERROR_CODES } from './constants';
 import { dataSource } from '../../../dataSources';
+import { getRunSqlQuery } from '../../../metadata/queryUtils';
 
 export const getPlaceholder = type => {
   switch (type) {

--- a/console/src/components/Services/Events/EventTriggers/state.ts
+++ b/console/src/components/Services/Events/EventTriggers/state.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { TableDefinition } from '../../../Common/utils/v1QueryUtils';
 import {
   URLConf,
   EventTriggerOperation,
@@ -17,10 +16,11 @@ import {
 import { parseServerHeaders } from '../../../Common/Headers/utils';
 import { Table } from '../../../../dataSources/types';
 import { generateTableDef } from '../../../../dataSources';
+import { QualifiedTable } from '../../../../metadata/types';
 
 export type LocalEventTriggerState = {
   name: string;
-  table: TableDefinition;
+  table: QualifiedTable;
   operations: Record<EventTriggerOperation, boolean>;
   operationColumns: ETOperationColumn[];
   webhook: URLConf;

--- a/console/src/components/Services/Events/ServerIO.ts
+++ b/console/src/components/Services/Events/ServerIO.ts
@@ -2,14 +2,6 @@ import { push, replace } from 'react-router-redux';
 import {
   fetchEventTriggersQuery,
   fetchScheduledTriggersQuery,
-  getBulkQuery,
-  generateCreateScheduledTriggerQuery,
-  getDropScheduledTriggerQuery,
-  generateUpdateScheduledTriggerQuery,
-  generateCreateEventTriggerQuery,
-  getDropEventTriggerQuery,
-  getCreateScheduledEventQuery,
-  getRedeliverDataEventQuery,
   getSelectQuery,
   makeOrderBy,
 } from '../../Common/utils/v1QueryUtils';
@@ -61,6 +53,16 @@ import {
 import { EventTriggerProperty } from './EventTriggers/Modify/utils';
 import { getLogsTableDef } from './utils';
 import { Table } from '../../../dataSources/types';
+import {
+  generateCreateEventTriggerQuery,
+  getDropEventTriggerQuery,
+  generateCreateScheduledTriggerQuery,
+  generateUpdateScheduledTriggerQuery,
+  getDropScheduledTriggerQuery,
+  getCreateScheduledEventQuery,
+  getRedeliverDataEventQuery,
+  getBulkQuery,
+} from '../../../metadata/queryUtils';
 
 export const fetchTriggers = (
   kind: Nullable<TriggerKind>

--- a/console/src/components/Services/Events/types.ts
+++ b/console/src/components/Services/Events/types.ts
@@ -1,8 +1,8 @@
 import { Action as ReduxAction } from 'redux';
 import { RouteComponentProps } from 'react-router';
-import { Header as ServerHeader } from '../../Common/utils/v1QueryUtils';
 import { Nullable } from '../../Common/utils/tsUtils';
 import { Dispatch } from '../../../types';
+import { ServerHeader } from '../../../metadata/types';
 
 export const LOADING_TRIGGERS = 'Events/LOADING_TRIGGERS';
 export const LOADED_TRIGGERS = 'Events/LOADED_TRIGGERS';

--- a/console/src/components/Services/Events/utils.ts
+++ b/console/src/components/Services/Events/utils.ts
@@ -7,11 +7,11 @@ import {
   ScheduledTrigger,
   EventKind,
 } from './types';
-import { TableDefinition } from '../../Common/utils/v1QueryUtils';
 import { convertDateTimeToLocale } from '../../Common/utils/jsUtils';
 import { Nullable } from '../../Common/utils/tsUtils';
 import { TableColumn, Table } from '../../../dataSources/types';
 import { generateTableDef, findTable } from '../../../dataSources';
+import { QualifiedTable } from '../../../metadata/types';
 
 export const parseServerWebhook = (
   webhook: Nullable<string>,
@@ -77,7 +77,7 @@ export const sanitiseRow = (column: string, row: Record<string, string>) => {
   return content;
 };
 
-export const getLogsTableDef = (kind: EventKind): TableDefinition => {
+export const getLogsTableDef = (kind: EventKind): QualifiedTable => {
   let tableName: string;
   switch (kind) {
     case 'data':

--- a/console/src/components/Services/RemoteSchema/graphqlUtils.js
+++ b/console/src/components/Services/RemoteSchema/graphqlUtils.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import endpoints from '../../../Endpoints';
-import { getRemoteSchemaIntrospectionQuery } from '../../Common/utils/v1QueryUtils';
 import { buildClientSchema, isWrappingType, isObjectType } from 'graphql';
 import requestAction from '../../../utils/requestAction';
+import { getRemoteSchemaIntrospectionQuery } from '../../../metadata/queryUtils';
 
 // local cache where introspection schema is cached
 let introspectionSchemaCache = {};

--- a/console/src/components/Services/Settings/About/About.tsx
+++ b/console/src/components/Services/Settings/About/About.tsx
@@ -9,9 +9,9 @@ import globals from '../../../../Globals';
 import styles from '../Settings.scss';
 import requestAction from '../../../../utils/requestAction';
 import { showErrorNotification } from '../../Common/Notification';
-import { getRunSqlQuery } from '../../../Common/utils/v1QueryUtils';
 import { versionGT } from '../../../../helpers/versionUtils';
 import { ReduxState, ConnectInjectedProps } from '../../../../types';
+import { getRunSqlQuery } from '../../../../metadata/queryUtils';
 
 type AboutState = {
   consoleAssetVersion?: string;

--- a/console/src/components/Services/Types/ServerIO.js
+++ b/console/src/components/Services/Types/ServerIO.js
@@ -3,10 +3,10 @@ import {
   reformCustomTypes,
   hydrateTypeRelationships,
 } from '../../../shared/utils/hasuraCustomTypeUtils';
-import { generateSetCustomTypesQuery } from '../../Common/utils/v1QueryUtils';
 import { getConfirmation } from '../../Common/utils/jsUtils';
 import { exportMetadata } from '../../../metadata/actions';
 import { customTypesSelector } from '../../../metadata/selector';
+import { generateSetCustomTypesQuery } from '../../../metadata/queryUtils';
 
 export const setCustomGraphQLTypes = (types, successCb, errorCb) => (
   dispatch,

--- a/console/src/dataSources/common.ts
+++ b/console/src/dataSources/common.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '../components/Common/utils/tsUtils';
 import { Table, Relationship, CheckConstraint, BaseTable } from './types';
-import { TableDefinition } from '../components/Common/utils/v1QueryUtils'; // TODO
 import { isEqual } from '../components/Common/utils/jsUtils';
+import { QualifiedTable } from '../metadata/types';
 
 export type Operations = 'insert' | 'select' | 'update' | 'delete';
 export const QUERY_TYPES: Operations[] = [
@@ -32,12 +32,12 @@ export const getTableDef = (table: Table) => {
   return generateTableDef(table.table_name, table.table_schema);
 };
 
-export const getQualifiedTableDef = (tableDef: TableDefinition | string) => {
+export const getQualifiedTableDef = (tableDef: QualifiedTable | string) => {
   return typeof tableDef === 'string' ? generateTableDef(tableDef) : tableDef;
 };
 
 export const getTableNameWithSchema = (
-  tableDef: TableDefinition,
+  tableDef: QualifiedTable,
   wrapDoubleQuotes = false
 ) => {
   let fullTableName;
@@ -51,7 +51,7 @@ export const getTableNameWithSchema = (
   return fullTableName;
 };
 
-export const findTable = (allTables: Table[], tableDef: TableDefinition) => {
+export const findTable = (allTables: Table[], tableDef: QualifiedTable) => {
   return allTables.find(t => isEqual(getTableDef(t), tableDef));
 };
 

--- a/console/src/dataSources/types.ts
+++ b/console/src/dataSources/types.ts
@@ -1,6 +1,6 @@
 import { Nullable } from '../components/Common/utils/tsUtils';
-import { FunctionDefinition } from '../components/Common/utils/v1QueryUtils';
 import { Column } from '../utils/postgresColumnTypes';
+import { FunctionDefinition } from '../metadata/types';
 
 export interface Relationship
   extends Pick<BaseTable, 'table_name' | 'table_schema'> {

--- a/console/src/metadata/actions.ts
+++ b/console/src/metadata/actions.ts
@@ -1,11 +1,4 @@
 import { Thunk, ReduxState } from '../types';
-import {
-  exportMetadataQuery,
-  generateReplaceMetadataQuery,
-  resetMetadataQuery,
-  inconsistentObjectsQuery,
-  dropInconsistentObjectsQuery,
-} from '../components/Common/utils/v1QueryUtils';
 import requestAction from '../utils/requestAction';
 import Endpoints, { globalCookiePolicy } from '../Endpoints';
 import { HasuraMetadataV2 } from './types';
@@ -28,6 +21,13 @@ import {
 } from '../components/Services/Data/DataActions';
 import { filterInconsistentMetadataObjects } from '../components/Services/Settings/utils';
 import { clearIntrospectionSchemaCache } from '../components/Services/RemoteSchema/graphqlUtils';
+import {
+  inconsistentObjectsQuery,
+  dropInconsistentObjectsQuery,
+  exportMetadataQuery,
+  generateReplaceMetadataQuery,
+  resetMetadataQuery,
+} from './queryUtils';
 
 export interface ExportMetadataSuccess {
   type: 'Metadata/EXPORT_METADATA_SUCCESS';

--- a/console/src/metadata/queryUtils.ts
+++ b/console/src/metadata/queryUtils.ts
@@ -1,0 +1,392 @@
+// Note: This file MUST contain all/only metadata requests
+
+import { terminateSql } from '../dataSources';
+import {
+  CustomRootFields,
+  ActionDefinition,
+  CustomTypes,
+  HasuraMetadataV2,
+  QualifiedTable,
+} from './types';
+import { transformHeaders } from '../components/Common/Headers/utils';
+import { LocalEventTriggerState } from '../components/Services/Events/EventTriggers/state';
+import { LocalScheduledTriggerState } from '../components/Services/Events/CronTriggers/state';
+import { LocalAdhocEventState } from '../components/Services/Events/AdhocEvents/Add/state';
+import { RemoteRelationshipPayload } from '../components/Services/Data/TableRelationships/RemoteRelationships/utils';
+
+export const getRunSqlQuery = (
+  sql: string,
+  shouldCascade?: boolean,
+  readOnly?: boolean
+) => ({
+  type: 'run_sql',
+  args: {
+    sql: terminateSql(sql),
+    cascade: !!shouldCascade,
+    read_only: !!readOnly,
+  },
+});
+
+export const getCreatePermissionQuery = (
+  action: string,
+  tableDef: QualifiedTable,
+  role: string,
+  permission: any
+) => {
+  return {
+    type: `create_${action}_permission`,
+    args: {
+      table: tableDef,
+      role,
+      permission,
+    },
+  };
+};
+
+export const getDropPermissionQuery = (
+  action: string,
+  tableDef: QualifiedTable,
+  role: string
+) => {
+  return {
+    type: `drop_${action}_permission`,
+    args: {
+      table: tableDef,
+      role,
+    },
+  };
+};
+
+export const generateSetCustomTypesQuery = (customTypes: CustomTypes) => {
+  return {
+    type: 'set_custom_types',
+    args: customTypes,
+  };
+};
+
+export const generateCreateActionQuery = (
+  name: string,
+  definition: ActionDefinition,
+  comment: string
+) => {
+  return {
+    type: 'create_action',
+    args: {
+      name,
+      definition,
+      comment,
+    },
+  };
+};
+
+export const getSetCustomRootFieldsQuery = (
+  tableDef: QualifiedTable,
+  rootFields: CustomRootFields,
+  customColumnNames: Record<string, string>
+) => {
+  return {
+    type: 'set_table_custom_fields',
+    version: 2,
+    args: {
+      table: tableDef,
+      custom_root_fields: rootFields,
+      custom_column_names: customColumnNames,
+    },
+  };
+};
+
+export const generateDropActionQuery = (name: string) => {
+  return {
+    type: 'drop_action',
+    args: {
+      name,
+    },
+  };
+};
+
+// TODO Refactor and accept role, filter and action name
+export const getCreateActionPermissionQuery = (
+  def: { role: string; filter: Record<string, any> },
+  actionName: string
+) => {
+  return {
+    type: 'create_action_permission',
+    args: {
+      action: actionName,
+      role: def.role,
+      definition: {
+        select: {
+          filter: def.filter,
+        },
+      },
+    },
+  };
+};
+
+export const getUpdateActionQuery = (
+  def: ActionDefinition,
+  actionName: string,
+  actionComment: string
+) => {
+  return {
+    type: 'update_action',
+    args: {
+      name: actionName,
+      definition: def,
+      comment: actionComment,
+    },
+  };
+};
+
+export const getDropActionPermissionQuery = (
+  role: string,
+  actionName: string
+) => {
+  return {
+    type: 'drop_action_permission',
+    args: {
+      action: actionName,
+      role,
+    },
+  };
+};
+
+export const getSetTableEnumQuery = (
+  tableDef: QualifiedTable,
+  isEnum: boolean
+) => {
+  return {
+    type: 'set_table_is_enum',
+    args: {
+      table: tableDef,
+      is_enum: isEnum,
+    },
+  };
+};
+
+export const getTrackTableQuery = (tableDef: QualifiedTable) => {
+  return {
+    type: 'add_existing_table_or_view',
+    args: tableDef,
+  };
+};
+
+export const getUntrackTableQuery = (tableDef: QualifiedTable) => {
+  return {
+    type: 'untrack_table',
+    args: {
+      table: tableDef,
+    },
+  };
+};
+
+export const getAddComputedFieldQuery = (
+  tableDef: QualifiedTable,
+  computedFieldName: string,
+  definition: any, // TODO
+  comment: string
+) => {
+  return {
+    type: 'add_computed_field',
+    args: {
+      table: tableDef,
+      name: computedFieldName,
+      definition: {
+        ...definition,
+      },
+      comment,
+    },
+  };
+};
+
+export const getDropComputedFieldQuery = (
+  tableDef: QualifiedTable,
+  computedFieldName: string
+) => {
+  return {
+    type: 'drop_computed_field',
+    args: {
+      table: tableDef,
+      name: computedFieldName,
+    },
+  };
+};
+
+export const inconsistentObjectsQuery = {
+  type: 'get_inconsistent_metadata',
+  args: {},
+};
+
+export const dropInconsistentObjectsQuery = {
+  type: 'drop_inconsistent_metadata',
+  args: {},
+};
+
+export const getReloadMetadataQuery = (shouldReloadRemoteSchemas: boolean) => ({
+  type: 'reload_metadata',
+  args: {
+    reload_remote_schemas: shouldReloadRemoteSchemas,
+  },
+});
+
+export const getReloadRemoteSchemaCacheQuery = (remoteSchemaName: string) => {
+  return {
+    type: 'reload_remote_schema',
+    args: {
+      name: remoteSchemaName,
+    },
+  };
+};
+
+export const exportMetadataQuery = {
+  type: 'export_metadata',
+  args: {},
+};
+
+export const generateReplaceMetadataQuery = (
+  metadataJson: HasuraMetadataV2
+) => ({
+  type: 'replace_metadata',
+  args: metadataJson,
+});
+
+export const resetMetadataQuery = {
+  type: 'clear_metadata',
+  args: {},
+};
+
+export const generateCreateEventTriggerQuery = (
+  state: LocalEventTriggerState,
+  replace = false
+) => ({
+  type: 'create_event_trigger',
+  args: {
+    name: state.name.trim(),
+    table: state.table,
+    webhook:
+      state.webhook.type === 'static' ? state.webhook.value.trim() : null,
+    webhook_from_env:
+      state.webhook.type === 'env' ? state.webhook.value.trim() : null,
+    insert: state.operations.insert
+      ? {
+          columns: '*',
+        }
+      : null,
+    update: state.operations.update
+      ? {
+          columns: state.operationColumns
+            .filter(c => !!c.enabled)
+            .map(c => c.name),
+        }
+      : null,
+    delete: state.operations.delete
+      ? {
+          columns: '*',
+        }
+      : null,
+    enable_manual: state.operations.enable_manual,
+    retry_conf: state.retryConf,
+    headers: transformHeaders(state.headers),
+    replace,
+  },
+});
+
+export const getDropEventTriggerQuery = (name: string) => ({
+  type: 'delete_event_trigger',
+  args: {
+    name: name.trim(),
+  },
+});
+
+export const generateCreateScheduledTriggerQuery = (
+  state: LocalScheduledTriggerState,
+  replace = false
+) => ({
+  type: 'create_cron_trigger',
+  args: {
+    name: state.name.trim(),
+    webhook: state.webhook,
+    schedule: state.schedule,
+    payload: JSON.parse(state.payload),
+    headers: transformHeaders(state.headers),
+    retry_conf: {
+      num_retries: state.retryConf.num_retries,
+      retry_interval_seconds: state.retryConf.interval_sec,
+      timeout_seconds: state.retryConf.timeout_sec,
+      tolerance_seconds: state.retryConf.tolerance_sec,
+    },
+    comment: state.comment,
+    include_in_metadata: state.includeInMetadata,
+    replace,
+  },
+});
+
+export const generateUpdateScheduledTriggerQuery = (
+  state: LocalScheduledTriggerState
+) => generateCreateScheduledTriggerQuery(state, true);
+
+export const getDropScheduledTriggerQuery = (name: string) => ({
+  type: 'delete_cron_trigger',
+  args: {
+    name: name.trim(),
+  },
+});
+
+export const getCreateScheduledEventQuery = (state: LocalAdhocEventState) => {
+  return {
+    type: 'create_scheduled_event',
+    args: {
+      webhook: state.webhook,
+      schedule_at: state.time.toISOString(),
+      headers: transformHeaders(state.headers),
+      retry_conf: {
+        num_retries: state.retryConf.num_retries,
+        retry_interval_seconds: state.retryConf.interval_sec,
+        timeout_seconds: state.retryConf.timeout_sec,
+        tolerance_seconds: state.retryConf.tolerance_sec,
+      },
+      payload: state.payload,
+      comment: state.comment,
+    },
+  };
+};
+
+export const getRedeliverDataEventQuery = (eventId: string) => ({
+  type: 'redeliver_event',
+  args: {
+    event_id: eventId,
+  },
+});
+
+export const getSaveRemoteRelQuery = (
+  args: RemoteRelationshipPayload,
+  isNew: boolean
+) => ({
+  type: `${isNew ? 'create' : 'update'}_remote_relationship`,
+  args,
+});
+
+export const getDropRemoteRelQuery = (name: string, table: QualifiedTable) => ({
+  type: 'delete_remote_relationship',
+  args: {
+    name,
+    table,
+  },
+});
+
+export const getRemoteSchemaIntrospectionQuery = (
+  remoteSchemaName: string
+) => ({
+  type: 'introspect_remote_schema',
+  args: {
+    name: remoteSchemaName,
+  },
+});
+
+// TODO?: maybe some better types for args
+export const getBulkQuery = (args: any[]) => {
+  return {
+    type: 'bulk',
+    args,
+  };
+};

--- a/console/src/metadata/types.ts
+++ b/console/src/metadata/types.ts
@@ -114,6 +114,11 @@ export interface Function {
   configuration?: FunctionConfiguration;
 }
 
+export interface FunctionDefinition {
+  name: string;
+  schema: string;
+}
+
 /**
  * Configuration for a CustomFunction
  * https://hasura.io/docs/1.0/graphql/manual/api-reference/schema-metadata-api/custom-functions.html#function-configuration
@@ -391,7 +396,7 @@ export interface EventTrigger {
   webhook?: string;
   webhook_from_env?: string;
   /** The SQL function */
-  headers?: Array<HeaderFromValue | HeaderFromEnv>;
+  headers?: ServerHeader[];
 }
 
 export interface EventTriggerDefinition {
@@ -416,22 +421,15 @@ export interface OperationSpec {
 
 /**
  * https://hasura.io/docs/1.0/graphql/manual/api-reference/schema-metadata-api/syntax-defs.html#headerfromvalue
+ * https://hasura.io/docs/1.0/graphql/manual/api-reference/schema-metadata-api/syntax-defs.html#headerfromenv
  */
-export interface HeaderFromValue {
+export interface ServerHeader {
   /** Name of the header */
   name: string;
   /** Value of the header */
-  value: string;
-}
-
-/**
- * https://hasura.io/docs/1.0/graphql/manual/api-reference/schema-metadata-api/syntax-defs.html#headerfromenv
- */
-export interface HeaderFromEnv {
-  /** Name of the header */
-  name: string;
-  /** Name of the environment variable which holds the value of the header */
-  value_from_env: string;
+  value?: string;
+  /** value obtained from env file */
+  value_from_env?: string;
 }
 
 /**
@@ -479,7 +477,7 @@ export interface CronTrigger {
   /** Any JSON payload which will be sent when the webhook is invoked. */
   payload?: Record<string, any>;
   /** List of headers to be sent with the webhook */
-  headers: Array<HeaderFromEnv | HeaderFromValue>;
+  headers: ServerHeader[];
   /**	Retry configuration if scheduled invocation delivery fails */
   retry_conf?: RetryConfST;
   /**	Flag to indicate whether a trigger should be included in the metadata. When a cron trigger is included in the metadata, the user will be able to export it when the metadata of the graphql-engine is exported. */
@@ -544,7 +542,7 @@ export interface RemoteSchema {
 export interface RemoteSchemaDef {
   url?: string;
   url_from_env?: string;
-  headers?: Array<HeaderFromEnv | HeaderFromValue>;
+  headers?: ServerHeader[];
   forward_client_headers?: boolean;
   timeout_seconds?: number;
 }
@@ -793,8 +791,8 @@ export interface Action {
 export interface ActionDefinition {
   arguments?: InputArgument[];
   output_type?: string;
-  kind?: string;
-  headers?: Array<HeaderFromEnv | HeaderFromValue>;
+  kind?: 'synchronous' | 'asynchronous';
+  headers?: ServerHeader[];
   forward_client_headers?: boolean;
   handler: WebhookURL;
   type?: 'mutation' | 'query';

--- a/console/src/metadata/utils.ts
+++ b/console/src/metadata/utils.ts
@@ -1,8 +1,8 @@
 import {
-  getReloadMetadataQuery,
   inconsistentObjectsQuery,
+  getReloadMetadataQuery,
   getReloadRemoteSchemaCacheQuery,
-} from '../components/Common/utils/v1QueryUtils';
+} from './queryUtils';
 
 export const allowedQueriesCollection = 'allowed-queries';
 

--- a/console/src/telemetry/Actions.ts
+++ b/console/src/telemetry/Actions.ts
@@ -3,10 +3,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import Endpoints, { globalCookiePolicy } from '../Endpoints';
 import requestAction from '../utils/requestAction';
 import dataHeaders from '../components/Services/Data/Common/Headers';
-import {
-  getRunSqlQuery,
-  getConsoleOptsQuery,
-} from '../components/Common/utils/v1QueryUtils';
+import { getConsoleOptsQuery } from '../components/Common/utils/v1QueryUtils';
 import {
   showErrorNotification,
   showSuccessNotification,
@@ -14,6 +11,7 @@ import {
 import globals from '../Globals';
 import defaultTelemetryState, { TelemetryState } from './state';
 import { GetReduxState, ReduxState } from '../types';
+import { getRunSqlQuery } from '../metadata/queryUtils';
 
 const SET_CONSOLE_OPTS = 'Telemetry/SET_CONSOLE_OPTS';
 const SET_NOTIFICATION_SHOWN = 'Telemetry/SET_NOTIFICATION_SHOWN';


### PR DESCRIPTION
here's what's been done:

1. Create a file in src/metadata called queryUtils.ts
2. Moved all METADATA requests to queryUtils
3. kept all RQL requests to existing file v1QueryUtils

although there are other places where RQL and METADATA requests exist but haven't considered them here. If you'd want then I shall refactor those methods as well. 