### PR TITLE
console: show logs tables

### DIFF
--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getSelectQuery, OrderBy, makeOrderBy } from '../utils/v1QueryUtils';
+import { OrderBy, makeOrderBy } from '../utils/v1QueryUtils';
 import requestAction from '../../../utils/requestAction';
 import { Dispatch } from '../../../types';
 import endpoints from '../../../Endpoints';
@@ -16,6 +16,7 @@ import { Nullable } from '../utils/tsUtils';
 import { isNotDefined } from '../utils/jsUtils';
 import { parseFilter } from './utils';
 import { QualifiedTable } from '../../../metadata/types';
+import { getCreateSQLQueryFromSelectQuery } from '../../../metadata/queryUtils';
 
 const defaultFilter = makeValueFilter('', null, '');
 const defaultSort = makeOrderBy('', 'asc');
@@ -49,28 +50,30 @@ export const useFilterQuery = (
         .map(f => parseFilter(f)),
     };
 
-    const orderBy = newSorts || [
-      ...state.sorts.filter(f => !!f.column),
-      ...presets.sorts,
-    ];
+    // const orderBy = newSorts || [
+    //   ...state.sorts.filter(f => !!f.column),
+    //   ...presets.sorts,
+    // ];
 
-    const query = getSelectQuery(
+    const offsetValue = isNotDefined(offset) ? state.offset : offset;
+    const limitValue = isNotDefined(limit) ? state.limit : limit;
+
+    const query = getCreateSQLQueryFromSelectQuery(
       'select',
+      where.$and[0].cron_event.trigger_name.$eq ?? '',
       table,
-      ['*', ...(relationships || []).map(r => ({ name: r, columns: ['*'] }))],
-      where,
-      isNotDefined(offset) ? state.offset : offset,
-      isNotDefined(limit) ? state.limit : limit,
-      orderBy
+      relationships ?? [],
+      limitValue ?? 10,
+      offsetValue ?? 0
     );
-    const countQuery = getSelectQuery(
+
+    const countQuery = getCreateSQLQueryFromSelectQuery(
       'count',
+      where.$and[0].cron_event.trigger_name.$eq ?? '',
       table,
-      ['*', ...(relationships || []).map(r => ({ name: r, columns: ['*'] }))],
-      where,
-      undefined,
-      undefined,
-      orderBy
+      relationships ?? [],
+      limitValue ?? 10,
+      offsetValue ?? 0
     );
 
     const options = {
@@ -81,8 +84,21 @@ export const useFilterQuery = (
     dispatch(
       requestAction(endpoints.query, options, undefined, undefined, true, true)
     ).then(
-      (data: any[]) => {
-        setRows(data);
+      (data: any) => {
+        const receivedData = data.result.slice(1);
+        const formattedData =
+          receivedData.map((val: any) => ({
+            id: val[0],
+            event_id: val[1],
+            status: val[2],
+            created_at: val[5],
+            request: val[3],
+            response: val[4],
+            tries: val[10],
+            next_retry_at: val[12],
+          })) ?? [];
+
+        setRows(formattedData);
         setLoading(false);
         if (offset !== undefined) {
           setState(s => ({ ...s, offset }));

--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -16,7 +16,7 @@ import { Nullable } from '../utils/tsUtils';
 import { isNotDefined } from '../utils/jsUtils';
 import { parseFilter } from './utils';
 import { QualifiedTable } from '../../../metadata/types';
-import { getLogSql } from '../../../metadata/queryUtils';
+import { getLogSql } from '../../../metadata/metadataTableUtils';
 
 const defaultFilter = makeValueFilter('', null, '');
 const defaultSort = makeOrderBy('', 'asc');

--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -73,7 +73,7 @@ export const useFilterQuery = (
       table,
       relationships ?? [],
       undefined,
-      undefined,
+      undefined
     );
 
     const options = {

--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -16,7 +16,7 @@ import { Nullable } from '../utils/tsUtils';
 import { isNotDefined } from '../utils/jsUtils';
 import { parseFilter } from './utils';
 import { QualifiedTable } from '../../../metadata/types';
-import { getCreateSQLQueryFromSelectQuery } from '../../../metadata/queryUtils';
+import { getLogSql } from '../../../metadata/queryUtils';
 
 const defaultFilter = makeValueFilter('', null, '');
 const defaultSort = makeOrderBy('', 'asc');
@@ -58,7 +58,7 @@ export const useFilterQuery = (
     const offsetValue = isNotDefined(offset) ? state.offset : offset;
     const limitValue = isNotDefined(limit) ? state.limit : limit;
 
-    const query = getCreateSQLQueryFromSelectQuery(
+    const query = getLogSql(
       'select',
       where.$and[0].cron_event.trigger_name.$eq ?? '',
       table,
@@ -67,7 +67,7 @@ export const useFilterQuery = (
       offsetValue ?? 0
     );
 
-    const countQuery = getCreateSQLQueryFromSelectQuery(
+    const countQuery = getLogSql(
       'count',
       where.$and[0].cron_event.trigger_name.$eq ?? '',
       table,

--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -72,8 +72,8 @@ export const useFilterQuery = (
       where.$and[0].cron_event.trigger_name.$eq ?? '',
       table,
       relationships ?? [],
-      limitValue ?? 10,
-      offsetValue ?? 0
+      undefined,
+      undefined,
     );
 
     const options = {

--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -369,6 +369,7 @@ const fetchFunctionInit = (schema = null) => (dispatch, getState) => {
 
 const updateCurrentSchema = (
   schemaName,
+  sourceName,
   redirect = true,
   schemaList = []
 ) => dispatch => {
@@ -377,7 +378,7 @@ const updateCurrentSchema = (
   }
 
   if (redirect) {
-    dispatch(_push(getSchemaBaseRoute(schemaName)));
+    dispatch(_push(getSchemaBaseRoute(schemaName, sourceName)));
   }
 
   Promise.all([

--- a/console/src/components/Services/Data/DataPageContainer.js
+++ b/console/src/components/Services/Data/DataPageContainer.js
@@ -38,7 +38,7 @@ const DataPageContainer = ({
     let newDriver;
     try {
       [newName, newDriver] = JSON.parse(value);
-    } catch (err) {
+    } catch {
       return;
     }
     setDriver(newDriver);
@@ -72,7 +72,7 @@ const DataPageContainer = ({
   }
 
   const handleSchemaChange = e => {
-    dispatch(updateCurrentSchema(e.target.value));
+    dispatch(updateCurrentSchema(e.target.value, currentDataSource));
   };
 
   const getSchemaOptions = () => {
@@ -107,7 +107,7 @@ const DataPageContainer = ({
               <label style={{ width: '70px' }}>Database:</label>
               <select
                 onChange={onDatabaseChange}
-                className={styles.changeSchema + ' form-control'}
+                className={`${styles.changeSchema} form-control`}
                 value={JSON.stringify([
                   currentDataSourceDetails.name,
                   currentDataSourceDetails.driver,

--- a/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
@@ -21,10 +21,19 @@ import { getInvocationLogStatus } from './utils';
 
 interface Props extends FilterTableProps {
   dispatch: Dispatch;
+  toParseFormatReqRes?: boolean;
 }
 
 const InvocationLogsTable: React.FC<Props> = props => {
-  const { rows, filterState, runQuery, columns, count, dispatch } = props;
+  const {
+    rows,
+    filterState,
+    runQuery,
+    columns,
+    count,
+    dispatch,
+    toParseFormatReqRes,
+  } = props;
   const [redeliveredEventId, setRedeliveredEventId] = React.useState<
     Nullable<string>
   >(null);
@@ -191,8 +200,20 @@ const InvocationLogsTable: React.FC<Props> = props => {
       SubComponent={logRow => {
         const finalIndex = logRow.index;
         const finalRow = rows[finalIndex];
-        const currentPayload = JSON.stringify(finalRow.request, null, 4);
-        const finalResponse = JSON.stringify(finalRow.response, null, 4);
+        let currentPayload = JSON.stringify(finalRow.request, null, 4);
+        let finalResponse = JSON.stringify(finalRow.response, null, 4);
+        if (toParseFormatReqRes) {
+          currentPayload = JSON.stringify(
+            JSON.parse(finalRow.request),
+            null,
+            4
+          );
+          finalResponse = JSON.stringify(
+            JSON.parse(finalRow.response),
+            null,
+            4
+          );
+        }
         return (
           <InvocationLogDetails
             requestPayload={currentPayload}

--- a/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
@@ -21,19 +21,10 @@ import { getInvocationLogStatus } from './utils';
 
 interface Props extends FilterTableProps {
   dispatch: Dispatch;
-  toParseFormatReqRes?: boolean;
 }
 
 const InvocationLogsTable: React.FC<Props> = props => {
-  const {
-    rows,
-    filterState,
-    runQuery,
-    columns,
-    count,
-    dispatch,
-    toParseFormatReqRes,
-  } = props;
+  const { rows, filterState, runQuery, columns, count, dispatch } = props;
   const [redeliveredEventId, setRedeliveredEventId] = React.useState<
     Nullable<string>
   >(null);
@@ -200,20 +191,16 @@ const InvocationLogsTable: React.FC<Props> = props => {
       SubComponent={logRow => {
         const finalIndex = logRow.index;
         const finalRow = rows[finalIndex];
-        let currentPayload = JSON.stringify(finalRow.request, null, 4);
-        let finalResponse = JSON.stringify(finalRow.response, null, 4);
-        if (toParseFormatReqRes) {
-          currentPayload = JSON.stringify(
-            JSON.parse(finalRow.request),
-            null,
-            4
-          );
-          finalResponse = JSON.stringify(
-            JSON.parse(finalRow.response),
-            null,
-            4
-          );
-        }
+        const currentPayload = JSON.stringify(
+          JSON.parse(finalRow.request),
+          null,
+          4
+        );
+        const finalResponse = JSON.stringify(
+          JSON.parse(finalRow.response),
+          null,
+          4
+        );
         return (
           <InvocationLogDetails
             requestPayload={currentPayload}

--- a/console/src/components/Services/Events/CronTriggers/Logs/Logs.tsx
+++ b/console/src/components/Services/Events/CronTriggers/Logs/Logs.tsx
@@ -37,7 +37,6 @@ const InvocationLogs: React.FC<Props> = props => {
       columns={['id', 'status', 'event_id', 'created_at']}
       identifier={triggerName}
       dispatch={dispatch}
-      toParseFormatReqRes
     />
   );
 

--- a/console/src/components/Services/Events/CronTriggers/Logs/Logs.tsx
+++ b/console/src/components/Services/Events/CronTriggers/Logs/Logs.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 const InvocationLogs: React.FC<Props> = props => {
   const { dispatch, currentTrigger } = props;
-  const triggerName = currentTrigger ? currentTrigger.name : '';
+  const triggerName = currentTrigger?.name ?? '';
 
   const renderRows: FilterRenderProp = (
     rows,

--- a/console/src/components/Services/Events/CronTriggers/Logs/Logs.tsx
+++ b/console/src/components/Services/Events/CronTriggers/Logs/Logs.tsx
@@ -18,6 +18,7 @@ type Props = {
 
 const InvocationLogs: React.FC<Props> = props => {
   const { dispatch, currentTrigger } = props;
+
   const triggerName = currentTrigger?.name ?? '';
 
   const renderRows: FilterRenderProp = (
@@ -36,6 +37,7 @@ const InvocationLogs: React.FC<Props> = props => {
       columns={['id', 'status', 'event_id', 'created_at']}
       identifier={triggerName}
       dispatch={dispatch}
+      toParseFormatReqRes
     />
   );
 

--- a/console/src/components/Services/Events/EventTriggers/Add/Add.tsx
+++ b/console/src/components/Services/Events/EventTriggers/Add/Add.tsx
@@ -12,9 +12,9 @@ import CollapsibleToggle from '../../../../Common/CollapsibleToggle/CollapsibleT
 import Button from '../../../../Common/Button/Button';
 import {
   updateSchemaInfo,
-  fetchSchemaList,
-  updateCurrentSchema,
-  UPDATE_CURRENT_DATA_SOURCE,
+  // fetchSchemaList,
+  // updateCurrentSchema,
+  // UPDATE_CURRENT_DATA_SOURCE,
 } from '../../../Data/DataActions';
 import { createEventTrigger } from '../../ServerIO';
 import Operations from '../Common/Operations';
@@ -25,7 +25,7 @@ import { mapDispatchToPropsEmpty } from '../../../../Common/utils/reactUtils';
 import { Table } from '../../../../../dataSources/types';
 import { getDataSources } from '../../../../../metadata/selector';
 import { DataSource } from '../../../../../metadata/types';
-import { NotSupportedNote } from '../../../../Common/NotSupportedNote';
+// import { NotSupportedNote } from '../../../../Common/NotSupportedNote';
 
 interface Props extends InjectedProps {}
 

--- a/console/src/components/Services/Events/Router.tsx
+++ b/console/src/components/Services/Events/Router.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Connect } from 'react-redux';
-import { Route, IndexRedirect, EnterHook, RouterState } from 'react-router';
+import { Route, IndexRedirect } from 'react-router';
+
 import Container from './Container';
-import { ReduxStore } from '../../../types';
 import {
   getDataEventsLandingRoute,
   getScheduledEventsLandingRoute,
@@ -51,90 +50,81 @@ import {
 } from './AdhocEvents';
 import { RightContainer } from '../../Common/Layout/RightContainer';
 
-const getTriggersRouter = (
-  connect: Connect,
-  store: ReduxStore,
-  composeOnEnterHooks: (hooks: EnterHook[]) => EnterHook
-) => {
-  return (
-    <Route path={eventsPrefix} component={Container}>
-      <IndexRedirect to={dataEventsPrefix} />
-      <Route path={dataEventsPrefix} component={RightContainer}>
-        <IndexRedirect to={getDataEventsLandingRoute('relative')} />
-        <Route path={getAddETRoute('relative')} component={AddEventTrigger} />
-        <Route
-          path={getETModifyRoute(':triggerName', 'relative')}
-          component={ModifyEventTrigger}
-        />
-        <Route
-          path={getETPendingEventsRoute(':triggerName', 'relative')}
-          component={ETPendingEvents}
-        />
-        <Route
-          path={getETProcessedEventsRoute(':triggerName', 'relative')}
-          component={ETProcessedEvents}
-        />
-        <Route
-          path={getETInvocationLogsRoute(':triggerName', 'relative')}
-          component={ETInvocationLogs}
-        />
-        <Route
-          path={getDataEventsLandingRoute('relative')}
-          component={EventTriggerLanding}
-        />
-      </Route>
-      <Route path={scheduledEventsPrefix} component={RightContainer}>
-        <IndexRedirect to={getScheduledEventsLandingRoute('relative')} />
-        <Route
-          path={getAddSTRoute('relative')}
-          component={AddScheduledTrigger}
-        />
-        <Route
-          path={getScheduledEventsLandingRoute('relative')}
-          component={ScheduledTriggerLanding}
-        />
-        <Route
-          path={getSTInvocationLogsRoute(':triggerName', 'relative')}
-          component={ScheduledTriggerLogs}
-        />
-        <Route
-          path={getSTPendingEventsRoute(':triggerName', 'relative')}
-          component={STPendingEvents}
-        />
-        <Route
-          path={getSTProcessedEventsRoute(':triggerName', 'relative')}
-          component={STProcessedEvents}
-        />
-        <Route
-          path={getSTModifyRoute(':triggerName', 'relative')}
-          component={ScheduledTriggeModify}
-        />
-      </Route>
-      <Route path={adhocEventsPrefix} component={RightContainer}>
-        <IndexRedirect to={getAdhocEventsInfoRoute('relative')} />
-        <Route
-          path={getAddAdhocEventRoute('relative')}
-          component={AddAdhocEvent}
-        />
-        <Route
-          path={getAdhocEventsLogsRoute('relative')}
-          component={AdhocEventLogs}
-        />
-        <Route
-          path={getAdhocPendingEventsRoute('relative')}
-          component={AdhocEventPendingEvents}
-        />
-        <Route
-          path={getAdhocProcessedEventsRoute('relative')}
-          component={AdhocEventProcessedEvents}
-        />
-        <Route
-          path={getAdhocEventsInfoRoute('relative')}
-          component={AdhocEventsInfo}
-        />
-      </Route>
+const getTriggersRouter = () => (
+  <Route path={eventsPrefix} component={Container}>
+    <IndexRedirect to={dataEventsPrefix} />
+    <Route path={dataEventsPrefix} component={RightContainer}>
+      <IndexRedirect to={getDataEventsLandingRoute('relative')} />
+      <Route path={getAddETRoute('relative')} component={AddEventTrigger} />
+      <Route
+        path={getETModifyRoute(':triggerName', 'relative')}
+        component={ModifyEventTrigger}
+      />
+      <Route
+        path={getETPendingEventsRoute(':triggerName', 'relative')}
+        component={ETPendingEvents}
+      />
+      <Route
+        path={getETProcessedEventsRoute(':triggerName', 'relative')}
+        component={ETProcessedEvents}
+      />
+      <Route
+        path={getETInvocationLogsRoute(':triggerName', 'relative')}
+        component={ETInvocationLogs}
+      />
+      <Route
+        path={getDataEventsLandingRoute('relative')}
+        component={EventTriggerLanding}
+      />
     </Route>
-  );
-};
+    <Route path={scheduledEventsPrefix} component={RightContainer}>
+      <IndexRedirect to={getScheduledEventsLandingRoute('relative')} />
+      <Route path={getAddSTRoute('relative')} component={AddScheduledTrigger} />
+      <Route
+        path={getScheduledEventsLandingRoute('relative')}
+        component={ScheduledTriggerLanding}
+      />
+      <Route
+        path={getSTInvocationLogsRoute(':triggerName', 'relative')}
+        component={ScheduledTriggerLogs}
+      />
+      <Route
+        path={getSTPendingEventsRoute(':triggerName', 'relative')}
+        component={STPendingEvents}
+      />
+      <Route
+        path={getSTProcessedEventsRoute(':triggerName', 'relative')}
+        component={STProcessedEvents}
+      />
+      <Route
+        path={getSTModifyRoute(':triggerName', 'relative')}
+        component={ScheduledTriggeModify}
+      />
+    </Route>
+    <Route path={adhocEventsPrefix} component={RightContainer}>
+      <IndexRedirect to={getAdhocEventsInfoRoute('relative')} />
+      <Route
+        path={getAddAdhocEventRoute('relative')}
+        component={AddAdhocEvent}
+      />
+      <Route
+        path={getAdhocEventsLogsRoute('relative')}
+        component={AdhocEventLogs}
+      />
+      <Route
+        path={getAdhocPendingEventsRoute('relative')}
+        component={AdhocEventPendingEvents}
+      />
+      <Route
+        path={getAdhocProcessedEventsRoute('relative')}
+        component={AdhocEventProcessedEvents}
+      />
+      <Route
+        path={getAdhocEventsInfoRoute('relative')}
+        component={AdhocEventsInfo}
+      />
+    </Route>
+  </Route>
+);
 
 export default getTriggersRouter;

--- a/console/src/components/Services/Events/ServerIO.ts
+++ b/console/src/components/Services/Events/ServerIO.ts
@@ -1,5 +1,4 @@
 import { push, replace } from 'react-router-redux';
-import { getRunSqlQuery } from '../../Common/utils/v1QueryUtils';
 import { Thunk } from '../../../types';
 import { makeMigrationCall } from '../Data/DataActions';
 import requestAction from '../../../utils/requestAction';
@@ -12,16 +11,13 @@ import {
 } from '../../Common/utils/routesUtils';
 import { transformHeaders } from '../../Common/Headers/utils';
 import { getConfirmation, isValidURL } from '../../Common/utils/jsUtils';
-import { Nullable } from '../../Common/utils/tsUtils';
-import Endpoints, { globalCookiePolicy } from '../../../Endpoints';
+import Endpoints from '../../../Endpoints';
 import dataHeaders from '../Data/Common/Headers';
 import {
-  TriggerKind,
   ScheduledTrigger,
   EventTrigger,
   EventKind,
   InvocationLog,
-  LOADING_TRIGGERS,
 } from './types';
 import { setCurrentTrigger } from './reducer';
 import { LocalScheduledTriggerState } from './CronTriggers/state';

--- a/console/src/dataSources/index.ts
+++ b/console/src/dataSources/index.ts
@@ -10,6 +10,7 @@ import {
 } from './types';
 import { PGFunction, FunctionState } from './services/postgresql/types';
 import { Operations } from './common';
+import { QualifiedTable } from '../metadata/types';
 
 export const drivers = ['postgres', 'mysql'];
 export type Driver = 'postgres' | 'mysql';
@@ -279,6 +280,14 @@ export interface DataSourcesAPI {
   deleteFunctionSql?: (
     schemaName: string,
     functionState: FunctionState
+  ) => string;
+  getInvocationLogSql?: (
+    type: 'cron' | 'scheduled',
+    invocationTable: QualifiedTable,
+    relationshipTable: QualifiedTable,
+    triggerName?: string,
+    limit?: number,
+    offset?: number
   ) => string;
 }
 

--- a/console/src/dataSources/index.ts
+++ b/console/src/dataSources/index.ts
@@ -289,6 +289,11 @@ export interface DataSourcesAPI {
     limit?: number,
     offset?: number
   ) => string;
+  getEventInvocationInfoByIDSql?: (
+    logTableDef: QualifiedTable,
+    eventLogTable: QualifiedTable,
+    eventId: string
+  ) => string;
 }
 
 export let currentDriver: Driver = 'postgres';

--- a/console/src/dataSources/services/mysql/index.tsx
+++ b/console/src/dataSources/services/mysql/index.tsx
@@ -220,4 +220,5 @@ WHERE
   getFKRelations,
   getReferenceOption: (option: string) => option,
   getInvocationLogSql: undefined,
+  getEventInvocationInfoByIDSql: undefined,
 };

--- a/console/src/dataSources/services/mysql/index.tsx
+++ b/console/src/dataSources/services/mysql/index.tsx
@@ -219,4 +219,5 @@ WHERE
   checkConstraintsSql: undefined, // todo
   getFKRelations,
   getReferenceOption: (option: string) => option,
+  getInvocationLogSql: undefined,
 };

--- a/console/src/dataSources/services/postgresql/index.tsx
+++ b/console/src/dataSources/services/postgresql/index.tsx
@@ -44,6 +44,7 @@ import {
   frequentlyUsedColumns,
   getFKRelations,
   deleteFunctionSql,
+  getInvocationLogSql,
 } from './sqlUtils';
 
 export const isTable = (table: Table) => {
@@ -434,4 +435,5 @@ export const postgres: DataSourcesAPI = {
   getFKRelations,
   getReferenceOption,
   deleteFunctionSql,
+  getInvocationLogSql,
 };

--- a/console/src/dataSources/services/postgresql/index.tsx
+++ b/console/src/dataSources/services/postgresql/index.tsx
@@ -45,6 +45,7 @@ import {
   getFKRelations,
   deleteFunctionSql,
   getInvocationLogSql,
+  getEventInvocationInfoByIDSql,
 } from './sqlUtils';
 
 export const isTable = (table: Table) => {
@@ -436,4 +437,5 @@ export const postgres: DataSourcesAPI = {
   getReferenceOption,
   deleteFunctionSql,
   getInvocationLogSql,
+  getEventInvocationInfoByIDSql,
 };

--- a/console/src/dataSources/services/postgresql/sqlUtils.ts
+++ b/console/src/dataSources/services/postgresql/sqlUtils.ts
@@ -1,6 +1,7 @@
 import { Table, FrequentlyUsedColumn } from '../../types';
 import { isColTypeString } from '.';
 import { FunctionState } from './types';
+import { QualifiedTable } from '../../../metadata/types';
 
 const sqlEscapeText = (rawText: string) => {
   let text = rawText;
@@ -1153,4 +1154,27 @@ export const deleteFunctionSql = (
   }
 
   return `DROP FUNCTION ${functionNameWithSchema}${functionArgString}`;
+};
+
+export const getInvocationLogSql = (
+  type: 'cron' | 'scheduled',
+  invocationTable: QualifiedTable,
+  relationshipTable: QualifiedTable,
+  triggerName?: string,
+  limit?: number,
+  offset?: number
+) => {
+  const eventRelTable = `${type}_table`;
+
+  // FIXME: this sql only works for cron triggers atm. need changes for one-off scheduled events
+  const sql = `SELECT original_table.*, ${eventRelTable}.*
+  FROM ${invocationTable.schema}.${invocationTable.name} original_table
+  JOIN "${relationshipTable.schema}"."${
+    relationshipTable.name
+  }" ${eventRelTable} ON original_table.event_id = ${eventRelTable}.id
+  WHERE ${eventRelTable}.trigger_name = '${triggerName}'
+  ORDER BY original_table.created_at ASC NULLS LAST
+  LIMIT ${limit ?? 10} OFFSET ${offset ?? 0};`;
+
+  return sql;
 };

--- a/console/src/dataSources/services/postgresql/sqlUtils.ts
+++ b/console/src/dataSources/services/postgresql/sqlUtils.ts
@@ -1178,3 +1178,18 @@ export const getInvocationLogSql = (
 
   return sql;
 };
+
+export const getEventInvocationInfoByIDSql = (
+  logTableDef: QualifiedTable,
+  eventLogTable: QualifiedTable,
+  eventId: string
+) => `
+  SELECT
+    original_table.*,
+    event.*
+  FROM
+  "${logTableDef.schema}"."${logTableDef.name}" original_table
+  JOIN "${eventLogTable.schema}"."${eventLogTable.name}" event ON original_table.event_id = event.id
+  WHERE original_table.event_id = '${eventId}'
+  ORDER BY original_table.created_at NULLS LAST DESC;
+`;

--- a/console/src/metadata/metadataTableUtils.ts
+++ b/console/src/metadata/metadataTableUtils.ts
@@ -1,0 +1,45 @@
+import { QualifiedTable } from './types';
+import { dataSource } from '../dataSources';
+import { getRunSqlQuery } from '../components/Common/utils/v1QueryUtils';
+
+export const getLogSql = (
+  queryType: 'select' | 'count',
+  triggerName: string,
+  table: QualifiedTable,
+  relationships: string[],
+  limit?: number,
+  offset?: number
+) => {
+  let eventType = 'cron';
+  // FIXME: test and change for scheduled events
+  if (relationships[0].includes('scheduled')) {
+    eventType = 'scheduled';
+  }
+
+  const relTable: QualifiedTable = {
+    schema: 'hdb_catalog',
+    name: `hdb_${eventType}_events`,
+  };
+
+  if (!dataSource.getInvocationLogSql) {
+    return;
+  }
+
+  const sql = dataSource.getInvocationLogSql(
+    'cron',
+    table,
+    relTable,
+    triggerName,
+    limit,
+    offset
+  );
+
+  // todo: wait for API / write new SQL for this.
+  // if (queryType === 'count') {
+  //   sql += ';';
+  // } else {
+  //   sql += ` LIMIT ${limit ?? 10} OFFSET ${offset ?? 0};`;
+  // }
+
+  return getRunSqlQuery(sql, 'default');
+};

--- a/console/src/metadata/queryUtils.ts
+++ b/console/src/metadata/queryUtils.ts
@@ -12,9 +12,8 @@ import { LocalEventTriggerState } from '../components/Services/Events/EventTrigg
 import { LocalScheduledTriggerState } from '../components/Services/Events/CronTriggers/state';
 import { LocalAdhocEventState } from '../components/Services/Events/AdhocEvents/Add/state';
 import { RemoteRelationshipPayload } from '../components/Services/Data/TableRelationships/RemoteRelationships/utils';
-import { Driver, currentDriver, dataSource } from '../dataSources';
+import { Driver, currentDriver } from '../dataSources';
 import { ConsoleState } from '../telemetry/state';
-import { getRunSqlQuery } from '../components/Common/utils/v1QueryUtils';
 
 export const metadataQueryTypes = [
   'add_source',
@@ -628,48 +627,6 @@ export const getSetConsoleStateQuery = (
 export const getConsoleStateQuery = {
   type: 'get_catalog_state',
   args: {},
-};
-
-export const getLogSql = (
-  queryType: 'select' | 'count',
-  triggerName: string,
-  table: QualifiedTable,
-  relationships: string[],
-  limit?: number,
-  offset?: number
-) => {
-  let eventType = 'cron';
-  // FIXME: test and change for scheduled events
-  if (relationships[0].includes('scheduled')) {
-    eventType = 'scheduled';
-  }
-
-  const relTable: QualifiedTable = {
-    schema: 'hdb_catalog',
-    name: `hdb_${eventType}_events`,
-  };
-
-  if (!dataSource.getInvocationLogSql) {
-    return;
-  }
-
-  const sql = dataSource.getInvocationLogSql(
-    'cron',
-    table,
-    relTable,
-    triggerName,
-    limit,
-    offset
-  );
-
-  // todo: wait for API / write new SQL for this.
-  // if (queryType === 'count') {
-  //   sql += ';';
-  // } else {
-  //   sql += ` LIMIT ${limit ?? 10} OFFSET ${offset ?? 0};`;
-  // }
-
-  return getRunSqlQuery(sql, 'default');
 };
 
 export const getInvocationLogsQuery = (

--- a/console/src/metadata/queryUtils.ts
+++ b/console/src/metadata/queryUtils.ts
@@ -649,7 +649,7 @@ export const getCreateSQLQueryFromSelectQuery = (
   JOIN ${eventLocTable} ${eventTypeTable} ON original_table.event_id = ${eventTypeTable}.id
   WHERE ${eventTypeTable}.trigger_name = '${triggerName}'
   ORDER BY original_table.created_at ASC NULLS LAST`;
-  
+
   if (queryType === 'count') {
     sql += ';';
   } else {

--- a/console/src/reducer.ts
+++ b/console/src/reducer.ts
@@ -1,5 +1,7 @@
 import { combineReducers } from 'redux';
+import { reducer as notifications } from 'react-notification-system-redux';
 import { routerReducer } from 'react-router-redux';
+
 import { dataReducer } from './components/Services/Data';
 import { remoteSchemaReducer } from './components/Services/RemoteSchema';
 import { actionsReducer } from './components/Services/Actions';
@@ -10,8 +12,6 @@ import mainReducer from './components/Main/Actions';
 import apiExplorerReducer from './components/Services/ApiExplorer/Actions';
 import progressBarReducer from './components/App/Actions';
 import telemetryReducer from './telemetry/Actions';
-
-import { reducer as notifications } from 'react-notification-system-redux';
 import { metadataReducer } from './metadata/reducer';
 
 const reducer = combineReducers({


### PR DESCRIPTION
What's done in this PR:

- [x] Fixes for the schema list and data source change selectors on Data page
- [x] added new query `getCreateSQLQueryFromSelectQuery` to get the cron invocation logs in SQL. (might need more changes) 
       - [ ] make `count` counterpart of this. (maybe a part of a new API)
       - [x] format the request and response part 
- [x] added a method `getEventInvocationInfoByIDSql` for the `getEventLogs` fn. 
- [x] invocation page for cron triggers.

##### TODO: will keep filling in with more details.