### PR TITLE
more data sources PR fixes

### DIFF
--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -135,9 +135,13 @@ export const useFilterQuery = (
             const dataObj: any = {};
             allKeys.forEach((key: string, idx: number) => {
               if (!dataObj[key]) {
-                // to mitigate the duplicate keys that maybe there
-                // TODO: for pending and processed, use event_id as the ID
-                dataObj[key] = values[idx];
+                // to avoid duplicate keys in the results
+                if (triggerOp !== 'invocation' && key === 'event_id') {
+                  dataObj.invocation_id = dataObj.id;
+                  dataObj.id = values[idx];
+                } else {
+                  dataObj[key] = values[idx];
+                }
               }
             });
             formattedData.push(dataObj);

--- a/console/src/components/Common/FilterQuery/state.ts
+++ b/console/src/components/Common/FilterQuery/state.ts
@@ -70,7 +70,6 @@ export const useFilterQuery = (
     let query = {};
     let endpoint = endpoints.metadata;
 
-    // FIXME: placing temp values until the API is fixed. the rest should be working fine.
     if (triggerType === 'scheduled') {
       if (triggerOp !== 'invocation') {
         query = getScheduledEvents(
@@ -129,26 +128,28 @@ export const useFilterQuery = (
       (data: any) => {
         if (triggerType === 'data') {
           // formatting of the data
-          const allKeys = data.results[0];
-          const resultsData = data.results.slice(0);
+          const allKeys = data.result[0];
+          const resultsData = data.result.slice(1);
           const formattedData: any = [];
           resultsData.forEach((values: any[]) => {
             const dataObj: any = {};
             allKeys.forEach((key: string, idx: number) => {
-              // FIXME: there may be duplicate keys here
-              dataObj[key] = values[idx];
+              if (!dataObj[key]) {
+                // to mitigate the duplicate keys that maybe there
+                // TODO: for pending and processed, use event_id as the ID
+                dataObj[key] = values[idx];
+              }
             });
             formattedData.push(dataObj);
           });
 
           if (limitValue && offsetValue) {
-            setRows(formattedData.slice(offsetValue, limitValue));
+            setRows(formattedData.slice(offsetValue, offsetValue + limitValue));
           } else {
             setRows(formattedData);
           }
-        }
-
-        if (triggerOp !== 'invocation' && triggerType !== 'data') {
+          setCount(formattedData.length);
+        } else if (triggerOp !== 'invocation') {
           setRows(data?.events ?? []);
         } else {
           setRows(data?.invocations ?? []);
@@ -167,8 +168,9 @@ export const useFilterQuery = (
             sorts: newSorts,
           }));
         }
-        // FIXME: 10 is the default size and hence using it here
-        setCount(data?.count ?? 10);
+        if (triggerType !== 'data') {
+          setCount(data?.count ?? 10);
+        }
       },
       () => {
         setError(true);

--- a/console/src/components/Main/ConsoleNotification.ts
+++ b/console/src/components/Main/ConsoleNotification.ts
@@ -31,7 +31,6 @@ export type ConsoleNotification = {
   scope?: NotificationScope;
 };
 
-// FIXME? : we may have to remove this
 export const defaultNotification: ConsoleNotification = {
   subject: 'No updates available at the moment',
   created_at: Date.now(),

--- a/console/src/components/Main/Main.scss
+++ b/console/src/components/Main/Main.scss
@@ -1536,10 +1536,6 @@
   .secureSectionText {
     display: none;
   }
-
-  .shareSection {
-    display: none;
-  }
 }
 
 @media (max-width: 1050px) {

--- a/console/src/components/Main/NotificationSection.tsx
+++ b/console/src/components/Main/NotificationSection.tsx
@@ -640,7 +640,7 @@ const HasuraNotifications: React.FC<
 
   useOnClickOutside([dropDownRef, wrapperRef], onClickOutside);
 
-  const onClickShareSection = () => {
+  const onClickNotificationButton = () => {
     if (showBadge) {
       if (console_opts?.console_notifications) {
         let updatedState = {};
@@ -719,11 +719,11 @@ const HasuraNotifications: React.FC<
   return (
     <>
       <div
-        className={`${styles.shareSection} ${
+        className={`${styles.shareSection} ${styles.headerRightNavbarBtn} ${
           isDropDownOpen ? styles.opened : ''
         } dropdown-toggle`}
         aria-expanded="false"
-        onClick={onClickShareSection}
+        onClick={onClickNotificationButton}
         ref={wrapperRef}
       >
         <i className={`fa fa-bell ${styles.bellIcon}`} />

--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -437,10 +437,7 @@ export const getSchemaList = (sourceType, sourceName) => (
     body: JSON.stringify(query),
   };
   return dispatch(requestAction(url, options)).then(
-    data => {
-      // FIXME?: what exactly should be happening here?
-      return data;
-    },
+    data => data,
     error => {
       console.error('Failed to fetch schema ' + JSON.stringify(error));
       return error;

--- a/console/src/components/Services/Data/RawSQL/RawSQL.js
+++ b/console/src/components/Services/Data/RawSQL/RawSQL.js
@@ -170,10 +170,6 @@ const RawSQL = ({
         });
 
         allObjectsTrackable = objects.every(object => {
-          if (object.type === 'function') {
-            return false;
-          }
-
           const objectName = [object.schema, object.name].join('.');
 
           if (trackedObjectNames.includes(objectName)) {

--- a/console/src/components/Services/Data/Schema/AddDataSource.tsx
+++ b/console/src/components/Services/Data/Schema/AddDataSource.tsx
@@ -32,10 +32,10 @@ const customSelectBoxStyles = {
   },
 };
 
-type CreateDatabaseProps = {
+type AddDataSourceProps = {
   onSubmit(data: DataSource, successCallback: () => void): void;
 };
-const CreateDatabase = ({ onSubmit }: CreateDatabaseProps) => {
+const AddDataSource = ({ onSubmit }: AddDataSourceProps) => {
   const [databaseName, setDatabaseName] = useState('');
   const [databaseType, setDatabaseType] = useState<Driver | null>(null);
   const [databaseUrl, setDatabaseUrl] = useState('');
@@ -182,4 +182,4 @@ const CreateDatabase = ({ onSubmit }: CreateDatabaseProps) => {
     />
   );
 };
-export default CreateDatabase;
+export default AddDataSource;

--- a/console/src/components/Services/Data/Schema/CreateDatabase.tsx
+++ b/console/src/components/Services/Data/Schema/CreateDatabase.tsx
@@ -51,11 +51,11 @@ const CreateDatabase = ({ onSubmit }: CreateDatabaseProps) => {
     if (databaseType === null) return;
     onSubmit(
       {
-        name: databaseName,
+        name: databaseName.trim(),
         driver: databaseType,
         fromEnv: urlType === 'from-env',
         connection_pool_settings: retryConf,
-        url: databaseUrl,
+        url: databaseUrl.trim(),
       },
       () => {
         setDatabaseUrl('');

--- a/console/src/components/Services/Data/Schema/ManageDatabase.tsx
+++ b/console/src/components/Services/Data/Schema/ManageDatabase.tsx
@@ -6,7 +6,7 @@ import Button from '../../../Common/Button/Button';
 import styles from '../../../Common/Common.scss';
 import { ReduxState } from '../../../../types';
 import BreadCrumb from '../../../Common/Layout/BreadCrumb/BreadCrumb';
-import CreateDatabase from './CreateDatabase';
+import AddDataSource from './AddDataSource';
 import { DataSource } from '../../../../metadata/types';
 import { Driver } from '../../../../dataSources';
 import {
@@ -148,7 +148,7 @@ const ManageDatabase: React.FC<ManageDatabaseProps> = ({
     (dispatch(reloadDataSource({ driver, name })) as any).then(cb); // todo
   };
 
-  const onCreateDataSource = (
+  const onSubmitAddDataSource = (
     data: DataSource,
     successCallback: () => void
   ) => {
@@ -215,7 +215,7 @@ const ManageDatabase: React.FC<ManageDatabaseProps> = ({
           </div>
           <hr />
         </div>
-        <CreateDatabase onSubmit={onCreateDataSource} />
+        <AddDataSource onSubmit={onSubmitAddDataSource} />
       </div>
     </RightContainer>
   );

--- a/console/src/components/Services/Events/Common/Components/EventsSubTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/EventsSubTable.tsx
@@ -110,7 +110,6 @@ const EventsSubTable: React.FC<Props> = ({
     }
     // TODO: handle a "loading" state
     const url = Endpoints.metadata;
-    // FIXME: doesn't work in the current version
     const payload = getEventInvocationsLogByID(triggerType, props.event.id);
     const options = {
       method: 'POST',

--- a/console/src/components/Services/Events/Common/Components/EventsSubTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/EventsSubTable.tsx
@@ -24,6 +24,7 @@ interface Props extends InjectedReduxProps {
   event: Event;
   makeAPICall?: boolean;
   triggerType?: SupportedEvents;
+  toParseJSON?: boolean;
 }
 
 type RenderSubTableProps = Omit<
@@ -38,6 +39,7 @@ const RenderEventSubTable: React.FC<RenderSubTableProps> = ({
   rows,
   rowsFormatted,
   headings,
+  ...props
 }) => (
   <div className={styles.addPadding20Px}>
     {event.webhook_conf && (
@@ -69,16 +71,21 @@ const RenderEventSubTable: React.FC<RenderSubTableProps> = ({
           showPagination={false}
           SubComponent={(logRow: any) => {
             const invocationLog = rows[logRow.index];
-            const currentPayload = JSON.stringify(
-              invocationLog.request,
-              null,
-              4
-            );
-            const finalResponse = JSON.stringify(
-              invocationLog.response,
-              null,
-              4
-            );
+            let currentPayload = JSON.stringify(invocationLog.request, null, 4);
+            let finalResponse = JSON.stringify(invocationLog.response, null, 4);
+            console.log({ j: props.toParseJSON });
+            if (props.toParseJSON) {
+              currentPayload = JSON.stringify(
+                JSON.parse(invocationLog.response),
+                null,
+                4
+              );
+              finalResponse = JSON.stringify(
+                JSON.parse(invocationLog.request),
+                null,
+                4
+              );
+            }
             return (
               <InvocationLogDetails
                 requestPayload={currentPayload}
@@ -134,6 +141,7 @@ const EventsSubTable: React.FC<Props> = ({
         rowsFormatted={props.rowsFormatted}
         headings={props.headings}
         rows={props.rows}
+        toParseJSON={props.toParseJSON}
       />
     );
   }

--- a/console/src/components/Services/Events/Common/Components/EventsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/EventsTable.tsx
@@ -48,6 +48,7 @@ interface Props extends FilterTableProps {
     onSuccess: () => void
   ) => void;
   triggerType?: SupportedEvents;
+  toParseJSON?: boolean; // this is for data triggers
 }
 
 const EventsTable: React.FC<Props> = props => {
@@ -152,16 +153,24 @@ const EventsTable: React.FC<Props> = props => {
     }
   });
 
-  const invocationColumns = ['status', 'id', 'created_at'];
+  const invocationColumns = ['status', 'invoid', 'created_at'];
+  const invocationDataTrigCols = ['status', 'invocation_id', 'created_at'];
 
   const invocationGridHeadings: GridHeadingProps[] = [expanderActions];
-
-  invocationColumns.forEach(column => {
-    invocationGridHeadings.push({
-      Header: column,
-      accessor: column,
+  const addToGridHeadings = (headAccArr: string[]) => {
+    headAccArr.forEach(column => {
+      invocationGridHeadings.push({
+        Header: column,
+        accessor: column,
+      });
     });
-  });
+  };
+
+  if (triggerType) {
+    addToGridHeadings(invocationColumns);
+  } else {
+    addToGridHeadings(invocationDataTrigCols);
+  }
 
   const rowsFormatted = rows.map(row => {
     const formattedRow = Object.keys(row).reduce((fr, col) => {
@@ -256,15 +265,11 @@ const EventsTable: React.FC<Props> = props => {
             />
           );
         }
-        const logs =
-          currentRow.logs ||
-          currentRow.cron_event_logs ||
-          currentRow.scheduled_event_logs ||
-          [];
+        const logs = [currentRow];
         const invocationRows = logs.map((r: any) => {
           const newRow: Record<string, JSX.Element> = {};
           // Insert cells corresponding to all rows
-          invocationColumns.forEach(col => {
+          invocationDataTrigCols.forEach(col => {
             newRow[col] = (
               <div
                 className={styles.tableCellCenterAlignedOverflow}
@@ -282,6 +287,7 @@ const EventsTable: React.FC<Props> = props => {
             rows={logs}
             rowsFormatted={invocationRows}
             headings={invocationGridHeadings}
+            toParseJSON={props.toParseJSON}
           />
         );
       }}

--- a/console/src/components/Services/Events/Common/Components/EventsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/EventsTable.tsx
@@ -63,9 +63,9 @@ const EventsTable: React.FC<Props> = props => {
   } = props;
 
   const [pg, setCurrentPage] = React.useState(0);
-  const [pgSize, setPageSize] = React.useState(filterState.limit);
+  const [pgSize, setPageSize] = React.useState(filterState.limit ?? 10);
 
-  if (rows.length === 0) {
+  if (!rows.length) {
     return <div className={styles.add_mar_top}>No data available</div>;
   }
 

--- a/console/src/components/Services/Events/Common/Components/EventsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/EventsTable.tsx
@@ -214,41 +214,27 @@ const EventsTable: React.FC<Props> = props => {
   });
 
   const getNumOfPages = (
-    currentLimit: number,
-    currentOffset: number,
     currentPageSize: number,
     currentCount: number | undefined
   ) => {
-    const calcPgSize = currentLimit - currentOffset;
-    let numOfPages = 0;
     if (currentCount) {
-      numOfPages = Math.ceil(currentCount / calcPgSize);
-    } else {
-      return currentPageSize;
+      return Math.ceil(currentCount / currentPageSize);
     }
 
-    return numOfPages;
+    return currentPageSize;
   };
 
   return (
     <ReactTable
       className="-highlight"
       data-test="events-table"
-      data={rowsFormatted.slice(
-        filterState.offset,
-        filterState.offset + pgSize
-      )}
+      data={rowsFormatted}
       columns={gridHeadings}
       resizable
       manual
       onPageChange={changePage}
       page={pg}
-      pages={getNumOfPages(
-        filterState.limit,
-        filterState.offset,
-        pgSize,
-        count
-      )}
+      pages={getNumOfPages(pgSize, count)}
       showPagination={count ? count > 10 : false}
       onPageSizeChange={changePageSize}
       sortable={false}

--- a/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
@@ -215,29 +215,20 @@ const InvocationLogsTable: React.FC<Props> = props => {
   });
 
   const getNumOfPages = (
-    currentLimit: number,
-    currentOffset: number,
     currentPageSize: number,
     currentCount: number | undefined
   ) => {
-    const calcPgSize = currentLimit - currentOffset;
-    let numOfPages = 0;
     if (currentCount) {
-      numOfPages = Math.ceil(currentCount / calcPgSize);
-    } else {
-      return currentPageSize;
+      return Math.ceil(currentCount / currentPageSize);
     }
 
-    return numOfPages;
+    return currentPageSize;
   };
 
   return (
     <ReactTable
       className="-highlight"
-      data={rowsFormatted.slice(
-        filterState.offset,
-        filterState.offset + pgSize
-      )}
+      data={rowsFormatted}
       columns={gridHeadings}
       minRows={0}
       resizable
@@ -247,27 +238,14 @@ const InvocationLogsTable: React.FC<Props> = props => {
       getResizerProps={getResizerProps}
       onPageChange={changePage}
       page={pg}
-      pages={getNumOfPages(
-        filterState.limit,
-        filterState.offset,
-        pgSize,
-        count
-      )}
+      pages={getNumOfPages(pgSize, count)}
       showPagination={count ? count > 10 : false}
       onPageSizeChange={changePageSize}
       SubComponent={logRow => {
         const finalIndex = logRow.index;
         const finalRow = rows[finalIndex];
-        const currentPayload = JSON.stringify(
-          finalRow?.request ?? {},
-          null,
-          4
-        );
-        const finalResponse = JSON.stringify(
-          finalRow?.response ?? {},
-          null,
-          4
-        );
+        const currentPayload = JSON.stringify(finalRow?.request ?? {}, null, 4);
+        const finalResponse = JSON.stringify(finalRow?.response ?? {}, null, 4);
         return (
           <InvocationLogDetails
             requestPayload={currentPayload}

--- a/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
@@ -41,6 +41,7 @@ const RedliverEventButton: React.FC<RedeliverButtonProps> = ({
 
 interface Props extends FilterTableProps {
   dispatch: Dispatch;
+  toParseJSON?: boolean;
 }
 
 const InvocationLogsTable: React.FC<Props> = props => {
@@ -244,8 +245,22 @@ const InvocationLogsTable: React.FC<Props> = props => {
       SubComponent={logRow => {
         const finalIndex = logRow.index;
         const finalRow = rows[finalIndex];
-        const currentPayload = JSON.stringify(finalRow?.request ?? {}, null, 4);
-        const finalResponse = JSON.stringify(finalRow?.response ?? {}, null, 4);
+        // TODO: create a function here
+        let currentPayload = JSON.stringify(finalRow?.request ?? {}, null, 4);
+        let finalResponse = JSON.stringify(finalRow?.response ?? {}, null, 4);
+        if (props.toParseJSON) {
+          // need this for data trigger logs
+          currentPayload = JSON.stringify(
+            JSON.parse(finalRow?.request ?? '{}'),
+            null,
+            4
+          );
+          finalResponse = JSON.stringify(
+            JSON.parse(finalRow?.response ?? '{}'),
+            null,
+            4
+          );
+        }
         return (
           <InvocationLogDetails
             requestPayload={currentPayload}

--- a/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
@@ -20,6 +20,7 @@ import { convertDateTimeToLocale } from '../../../../Common/utils/jsUtils';
 import { Nullable } from '../../../../Common/utils/tsUtils';
 import { getInvocationLogStatus } from './utils';
 import Button from '../../../../Common/Button/Button';
+import { QualifiedTable } from '../../../../../metadata/types';
 
 type RedeliverButtonProps = {
   onClickHandler: (e: React.MouseEvent) => void;
@@ -42,6 +43,8 @@ const RedliverEventButton: React.FC<RedeliverButtonProps> = ({
 interface Props extends FilterTableProps {
   dispatch: Dispatch;
   toParseJSON?: boolean;
+  tableDef?: QualifiedTable;
+  tableSource?: string;
 }
 
 const InvocationLogsTable: React.FC<Props> = props => {
@@ -53,11 +56,20 @@ const InvocationLogsTable: React.FC<Props> = props => {
   const [pg, setCurrentPage] = React.useState(0);
   const [pgSize, setPageSize] = React.useState(filterState.limit);
 
-  const redeliverHandler = (eventId: string) => {
+  const redeliverHandler = (
+    eventId: string,
+    tableDef?: QualifiedTable,
+    tableSource?: string
+  ) => {
+    if (!tableDef || !tableSource) {
+      return;
+    }
     setIsRedelivering(true);
     dispatch(
       redeliverDataEvent(
         eventId,
+        tableDef,
+        tableSource,
         () => {
           setRedeliveredEventId(eventId);
           setIsRedelivering(false);
@@ -142,7 +154,11 @@ const InvocationLogsTable: React.FC<Props> = props => {
                 if (isRedelivering) {
                   return;
                 }
-                redeliverHandler(row.event_id);
+                redeliverHandler(
+                  row.event_id,
+                  props.tableDef,
+                  props.tableSource
+                );
                 e.stopPropagation();
               }}
             />

--- a/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
@@ -258,14 +258,13 @@ const InvocationLogsTable: React.FC<Props> = props => {
       SubComponent={logRow => {
         const finalIndex = logRow.index;
         const finalRow = rows[finalIndex];
-        // FIXME: once the new invocation logs APIs have been hooked up
         const currentPayload = JSON.stringify(
-          JSON.parse(finalRow?.request ?? '{}'),
+          finalRow?.request ?? {},
           null,
           4
         );
         const finalResponse = JSON.stringify(
-          JSON.parse(finalRow?.response ?? '{}'),
+          finalRow?.response ?? {},
           null,
           4
         );

--- a/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
+++ b/console/src/components/Services/Events/Common/Components/InvocationLogsTable.tsx
@@ -91,7 +91,11 @@ const InvocationLogsTable: React.FC<Props> = props => {
         onCancel={() => setRedeliveredEventId(null)}
         customClass={styles.redeliverModal}
       >
-        <RedeliverEvent eventId={redeliveredEventId} dispatch={dispatch} />
+        <RedeliverEvent
+          eventId={redeliveredEventId}
+          dispatch={dispatch}
+          eventDataSource={props.tableSource ?? 'default'}
+        />
       </Modal>
     );
   };

--- a/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
+++ b/console/src/components/Services/Events/Common/Components/RedeliverEvent.tsx
@@ -11,9 +11,14 @@ import { Dispatch } from '../../../../../types';
 type Props = {
   eventId: string;
   dispatch: Dispatch;
+  eventDataSource: string;
 };
 
-const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
+const RedeliverEvent: React.FC<Props> = ({
+  dispatch,
+  eventId,
+  eventDataSource,
+}) => {
   const [error, setError] = React.useState<null | Error>(null);
   const [logs, setLogs] = React.useState<InvocationLog[]>([]);
 
@@ -23,6 +28,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
         getEventLogs(
           eventId,
           'data',
+          eventDataSource,
           l => {
             setLogs(l);
           },
@@ -46,8 +52,16 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
 
   const latestLog = logs[0];
 
-  if (!logs.length) {
+  if (!logs.length && !error) {
+    // TODO: if there's a error on the query, then handle it here. can't keep showing the loader
     return <Spinner />;
+  }
+
+  if (error) {
+    // TODO: better UI for this error
+    return (
+      <>There was an error in fetching the details of the recent invocations.</>
+    );
   }
 
   return (
@@ -62,7 +76,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
               mode="json"
               theme="github"
               name="event_payload"
-              value={JSON.stringify(latestLog.request, null, 4)}
+              value={JSON.stringify(JSON.parse(latestLog.request), null, 4)}
               minLines={10}
               maxLines={30}
               width="100%"
@@ -82,7 +96,7 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
               theme="github"
               name="event_payload"
               value={JSON.stringify(
-                error === null ? latestLog.response : error,
+                error === null ? JSON.parse(latestLog.response) : error,
                 null,
                 4
               )}
@@ -115,8 +129,16 @@ const RedeliverEvent: React.FC<Props> = ({ dispatch, eventId }) => {
             SubComponent={(logRow: any) => {
               const finalIndex = logRow.index;
               const finalRow = logs[finalIndex];
-              const currentPayload = JSON.stringify(finalRow.request, null, 4);
-              const finalResponse = JSON.stringify(finalRow.response, null, 4);
+              const currentPayload = JSON.stringify(
+                JSON.parse(finalRow.request),
+                null,
+                4
+              );
+              const finalResponse = JSON.stringify(
+                JSON.parse(finalRow.response),
+                null,
+                4
+              );
               return (
                 <InvocationLogDetails
                   requestPayload={currentPayload}

--- a/console/src/components/Services/Events/EventTriggers/Add/Add.tsx
+++ b/console/src/components/Services/Events/EventTriggers/Add/Add.tsx
@@ -85,20 +85,6 @@ const Add: React.FC<Props> = props => {
     setState.table(undefined, selectedSchemaName);
   };
 
-  // todo
-  // const handleDataSourceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-  //   const selectedSourceName = e.target.value;
-  //   dispatch(fetchSchemaList()).then((data: any) => {
-  //     const schemas = data.result;
-  //     if (schemas.length) {
-  //       dispatch(updateCurrentSchema(schemas[1][0], false, data));
-  //     } else {
-  //       dispatch(updateCurrentSchema('', false, []));
-  //     }
-  //   });
-  //   setState.source(selectedSourceName);
-  // };
-
   const handleTableChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedTableName = e.target.value;
     setState.table(selectedTableName);
@@ -224,33 +210,6 @@ const Add: React.FC<Props> = props => {
               maxLength={42}
             />
             <hr />
-            {/* <div className={styles.add_mar_bottom}>
-              <h4 className={styles.subheading_text_no_padd}>
-                Data Source &nbsp; &nbsp;
-                <OverlayTrigger
-                  placement="right"
-                  overlay={tooltip.dataSourceDescription}
-                >
-                  <i className="fa fa-question-circle" aria-hidden="true" />
-                </OverlayTrigger>{' '}
-              </h4>
-              <NotSupportedNote unsupported={['mysql']} />
-            </div>
-            <select
-              onChange={handleDataSourceChange}
-              data-test="select-datasource-event-trigger"
-              className={`${styles.selectTrigger} form-control`}
-              value={source}
-            >
-              {dataSourcesList.map(s => {
-                return (
-                  <option value={s.name} key={s.name}>
-                    {s.name}
-                  </option>
-                );
-              })}
-            </select>
-            <hr /> */}
             <h4 className={styles.subheading_text}>
               Schema/Table &nbsp; &nbsp;
               <OverlayTrigger

--- a/console/src/components/Services/Events/EventTriggers/Common/eventLogsMapStateToProps.ts
+++ b/console/src/components/Services/Events/EventTriggers/Common/eventLogsMapStateToProps.ts
@@ -1,11 +1,12 @@
 import { connect, ConnectedProps } from 'react-redux';
 import { MapStateToProps, Dispatch } from '../../../../../types';
-import { RouterTriggerProps } from '../../types';
+import { RouterTriggerProps, EventTrigger } from '../../types';
 import { NotFoundError } from '../../../../Error/PageNotFound';
 import { getEventTriggerByName } from '../../../../../metadata/selector';
 
 type PropsFromState = {
   triggerName: string;
+  currentTrigger: EventTrigger;
   readOnlyMode: boolean;
   currentSource: string;
 };
@@ -24,6 +25,7 @@ const mapStateToProps: MapStateToProps<PropsFromState, RouterTriggerProps> = (
 
   return {
     triggerName,
+    currentTrigger,
     readOnlyMode: state.main.readOnlyMode,
     currentSource: state.tables.currentDataSource,
   };

--- a/console/src/components/Services/Events/EventTriggers/InvocationLogs/InvocationLogs.tsx
+++ b/console/src/components/Services/Events/EventTriggers/InvocationLogs/InvocationLogs.tsx
@@ -17,7 +17,13 @@ import {
 interface Props extends EventsLogsInjectedProps {}
 
 const InvocationLogs: React.FC<Props> = props => {
-  const { dispatch, triggerName, readOnlyMode, currentSource } = props;
+  const {
+    dispatch,
+    triggerName,
+    readOnlyMode,
+    currentSource,
+    currentTrigger,
+  } = props;
 
   const renderRows: FilterRenderProp = (
     rows,
@@ -32,17 +38,15 @@ const InvocationLogs: React.FC<Props> = props => {
       count={count}
       setFilterState={setFilterState}
       runQuery={runQuery}
-      columns={[
-        'id',
-        'redeliver',
-        'status',
-        'event_id',
-        // 'operation',
-        'created_at',
-      ]}
+      columns={['id', 'redeliver', 'status', 'event_id', 'created_at']}
       identifier={triggerName}
       dispatch={dispatch}
       toParseJSON
+      tableDef={{
+        name: currentTrigger.table_name,
+        schema: currentTrigger.schema_name,
+      }}
+      tableSource={currentSource}
     />
   );
 

--- a/console/src/components/Services/Events/EventTriggers/InvocationLogs/InvocationLogs.tsx
+++ b/console/src/components/Services/Events/EventTriggers/InvocationLogs/InvocationLogs.tsx
@@ -42,6 +42,7 @@ const InvocationLogs: React.FC<Props> = props => {
       ]}
       identifier={triggerName}
       dispatch={dispatch}
+      toParseJSON
     />
   );
 

--- a/console/src/components/Services/Events/EventTriggers/PendingEvents/PendingEvents.tsx
+++ b/console/src/components/Services/Events/EventTriggers/PendingEvents/PendingEvents.tsx
@@ -33,6 +33,7 @@ const PendingEvents: React.FC<Props> = props => {
       runQuery={runQuery}
       columns={['id', 'delivered', 'created_at', 'tries']}
       identifier={triggerName}
+      toParseJSON
     />
   );
 

--- a/console/src/components/Services/Events/EventTriggers/ProcessedEvents/ProcessedEvents.tsx
+++ b/console/src/components/Services/Events/EventTriggers/ProcessedEvents/ProcessedEvents.tsx
@@ -34,6 +34,7 @@ const ProcessedEvents: React.FC<Props> = props => {
       runQuery={runQuery}
       columns={['id', 'delivered', 'created_at', 'tries']}
       identifier={triggerName}
+      toParseJSON
     />
   );
 

--- a/console/src/components/Services/Events/ServerIO.ts
+++ b/console/src/components/Services/Events/ServerIO.ts
@@ -617,7 +617,6 @@ export const getEventLogs = (
       request: resultData[3],
       response: resultData[4],
     };
-    // FIXME: I'm not sure if this is the only thing that is required.
     successCallback([formattedData]);
   }, errorCallback);
 };

--- a/console/src/components/Services/Events/ServerIO.ts
+++ b/console/src/components/Services/Events/ServerIO.ts
@@ -541,14 +541,21 @@ export const createScheduledEvent = (
 
 export const redeliverDataEvent = (
   eventId: string,
+  tableDef: QualifiedTable,
+  eventTriggerSource: string,
   successCb?: CallableFunction,
   errorCb?: CallableFunction
 ): Thunk => (dispatch, getState) => {
   const url = Endpoints.metadata;
+  const payload = getRedeliverDataEventQuery(
+    eventId,
+    tableDef,
+    eventTriggerSource
+  );
   const options = {
     method: 'POST',
     headers: dataHeaders(getState),
-    body: JSON.stringify(getRedeliverDataEventQuery(eventId)),
+    body: JSON.stringify(payload),
   };
   return dispatch(
     requestAction(url, options, undefined, undefined, true, true)

--- a/console/src/components/Services/Events/ServerIO.ts
+++ b/console/src/components/Services/Events/ServerIO.ts
@@ -583,6 +583,7 @@ export const redeliverDataEvent = (
 export const getEventLogs = (
   eventId: string,
   eventKind: EventKind,
+  eventDataSource: string,
   successCallback: (logs: InvocationLog[]) => void,
   errorCallback: (error: any) => void
 ): Thunk => dispatch => {
@@ -600,7 +601,7 @@ export const getEventLogs = (
     eventLogTable,
     eventId
   );
-  const query = getRunSqlQuery(sql, 'default');
+  const query = getRunSqlQuery(sql, eventDataSource);
 
   dispatch(
     requestAction(
@@ -614,18 +615,38 @@ export const getEventLogs = (
       true,
       true
     )
-  ).then((data: { result: string[][] }) => {
-    const resultData = data.result[0][1];
-    const formattedData: InvocationLog = {
-      event_id: resultData[1],
-      id: resultData[0],
-      status: parseInt(resultData[2], 10),
-      created_at: resultData[5],
-      request: resultData[3],
-      response: resultData[4],
-    };
-    successCallback([formattedData]);
-  }, errorCallback);
+  )
+    .then((data: any) => {
+      const allKeys = data.result[0];
+      const dataRows = data.result.slice(1);
+      const invocationsKeys = [
+        'id',
+        'event_id',
+        'status',
+        'created_at',
+        'request',
+        'response',
+      ];
+      const formattedData: InvocationLog[] = dataRows.reduce(
+        (acc: InvocationLog[], val: any) => {
+          const newObj: any = {};
+          allKeys.forEach((key: string, idx: number) => {
+            if (invocationsKeys.includes(key) && !newObj[key]) {
+              newObj[key] = val[idx];
+            }
+          });
+          if (Object.keys(newObj)) {
+            return [...acc, newObj];
+          }
+          return acc;
+        },
+        []
+      );
+      successCallback(formattedData);
+    })
+    .catch(err => {
+      errorCallback(err);
+    });
 };
 
 export const cancelEvent = (

--- a/console/src/dataSources/services/mysql/index.tsx
+++ b/console/src/dataSources/services/mysql/index.tsx
@@ -120,7 +120,7 @@ const commonDataTypes = [
   },
 ];
 
-const createSQLRegex = /create\s*((?:|or\s*replace)\s*view|\s*(table|function|view))\s*(?:\s*if*\s*not\s*exists\s*)?(((\`?\w+\`?)\.(\`?\w+\`?))|(\`?\w+\`?))/; // eslint-disable-line
+const createSQLRegex = /create\s*((?:|or\s*replace)\s*view|\s*(table|function|view))\s*(?:\s*if*\s*not\s*exists\s*)?(((\`?\w+\`?)\.(\`?\w+\`?))|(\`?\w+\`?))/g; // eslint-disable-line
 
 export const mysql: DataSourcesAPI = {
   getFunctionSchema: () => {

--- a/console/src/dataSources/services/postgresql/index.tsx
+++ b/console/src/dataSources/services/postgresql/index.tsx
@@ -326,7 +326,7 @@ export const isColTypeString = (colType: string) =>
 
 const dependencyErrorCode = '2BP01'; // pg dependent error > https://www.postgresql.org/docs/current/errcodes-appendix.html
 
-const createSQLRegex = /create\s*(?:|or\s*replace)\s*(view|table|function)\s*(?:\s*if*\s*not\s*exists\s*)?((\"?\w+\"?)\.(\"?\w+\"?)|(\"?\w+\"?))/; // eslint-disable-line
+const createSQLRegex = /create\s*(?:|or\s*replace)\s*(view|table|function)\s*(?:\s*if*\s*not\s*exists\s*)?((\"?\w+\"?)\.(\"?\w+\"?)|(\"?\w+\"?))/g; // eslint-disable-line
 
 const isTimeoutError = (error: {
   code: string;

--- a/console/src/dataSources/services/postgresql/sqlUtils.ts
+++ b/console/src/dataSources/services/postgresql/sqlUtils.ts
@@ -1168,5 +1168,5 @@ export const getEventInvocationInfoByIDSql = (
   "${logTableDef.schema}"."${logTableDef.name}" original_table
   JOIN "${eventLogTable.schema}"."${eventLogTable.name}" event ON original_table.event_id = event.id
   WHERE original_table.event_id = '${eventId}'
-  ORDER BY original_table.created_at NULLS LAST DESC;
+  ORDER BY original_table.created_at DESC NULLS LAST;
 `;

--- a/console/src/metadata/queryUtils.ts
+++ b/console/src/metadata/queryUtils.ts
@@ -640,7 +640,6 @@ export const getConsoleStateQuery = {
 
 export type SupportedEvents = 'cron' | 'one_off';
 
-// FIXME: this does not work anymore, new API needs to support this too, to make it work
 export const getEventInvocationsLogByID = (
   type: SupportedEvents,
   event_id: string

--- a/console/src/metadata/queryUtils.ts
+++ b/console/src/metadata/queryUtils.ts
@@ -475,9 +475,15 @@ export const getCreateScheduledEventQuery = (
   };
 };
 
-export const getRedeliverDataEventQuery = (eventId: string) => ({
-  type: 'redeliver_event',
+export const getRedeliverDataEventQuery = (
+  eventId: string,
+  tableDef: QualifiedTable,
+  source: string
+) => ({
+  type: 'pg_redeliver_event',
   args: {
+    source,
+    table: tableDef,
     event_id: eventId,
   },
 });


### PR DESCRIPTION
- [x] make the notification icon visible on small screens
- [x] fix the cron and one-off triggers based on the latest APIs
- [x] Fix rendering of the Data Trigger tables
- [x] Fix the `createSQLRegex`, it works for views, functions, and tables now
- [x] Fix the redeliver button for data triggers 

### In Progress 

- [-] Notification badge status isn't updated correctly
- [-] Check notifications related stuff 

### TODO & some other issues on this PR or somethings I noticed

- Issue: On the redeliver event modal, why do we require a `setInterval` to keep querying every 2 seconds? Because we only have one call to the redeliver event function and so the invocations won't change.
- Issue?: Pending events was populated on redelivering events from a particular event. Need to check if this case is the expected one.
