### PR TITLE
console: more changes for the metadata PR

### DIFF
--- a/console/src/components/Common/utils/routesUtils.ts
+++ b/console/src/components/Common/utils/routesUtils.ts
@@ -9,12 +9,10 @@ import { ReduxState } from '../../../types';
 export const getSchemaBaseRoute = (
   schemaName: string,
   sourceName = 'default'
-) => {
-  // return `${globals.urlPrefix}/data/${source}/schema/${schemaName}`;
-  return `/data/${encodeURIComponent(sourceName)}/schema/${encodeURIComponent(
+) =>
+  `/data/${encodeURIComponent(sourceName)}/schema/${encodeURIComponent(
     schemaName
   )}`;
-};
 
 export const getSchemaAddTableRoute = (
   schemaName: string,
@@ -41,11 +39,10 @@ const getTableBaseRoute = (
   sourceName: string,
   tableName: string,
   isTable: boolean
-) => {
-  return `${getSchemaBaseRoute(schemaName, sourceName)}/${
+) =>
+  `${getSchemaBaseRoute(schemaName, sourceName)}/${
     isTable ? 'tables' : 'views'
   }/${encodeURIComponent(tableName)}`;
-};
 
 export const getTableBrowseRoute = (
   schemaName: string,

--- a/console/src/components/Services/Data/Add/AddExistingTableViewActions.js
+++ b/console/src/components/Services/Data/Add/AddExistingTableViewActions.js
@@ -53,8 +53,7 @@ const addExistingTableSql = (name, customSchema, skipRouting = false) => {
       currentDataSource
     );
 
-    const migrationName =
-      'add_existing_table_or_view_' + currentSchema + '_' + tableName;
+    const migrationName = `add_existing_table_or_view_${currentSchema}_${tableName}`;
 
     const requestMsg = 'Adding existing table/view...';
     const successMsg = 'Existing table/view added';
@@ -89,7 +88,7 @@ const addExistingTableSql = (name, customSchema, skipRouting = false) => {
       dispatch({ type: REQUEST_ERROR, data: err });
     };
 
-    makeMigrationCall(
+    return makeMigrationCall(
       dispatch,
       getState,
       [requestBodyUp],
@@ -124,7 +123,7 @@ const addExistingFunction = (name, customSchema, skipRouting = false) => {
       currentDataSource
     );
 
-    const migrationName = 'add_existing_function ' + currentSchema + '_' + name;
+    const migrationName = `add_existing_function_${currentSchema}_${name}`;
 
     const requestMsg = 'Adding existing function...';
     const successMsg = 'Existing function added';
@@ -143,7 +142,7 @@ const addExistingFunction = (name, customSchema, skipRouting = false) => {
       dispatch({ type: REQUEST_ERROR, data: err });
     };
 
-    makeMigrationCall(
+    return makeMigrationCall(
       dispatch,
       getState,
       [requestBodyUp],

--- a/console/src/components/Services/Data/DataActions.js
+++ b/console/src/components/Services/Data/DataActions.js
@@ -482,7 +482,7 @@ const makeMigrationCall = (
   errorMsg,
   shouldSkipSchemaReload,
   skipExecution = false,
-  isRetry
+  isRetry = false
 ) => {
   const source = getState().tables.currentDataSource;
   const upQuery = {
@@ -542,7 +542,7 @@ const makeMigrationCall = (
   const onSuccess = data => {
     if (!shouldSkipSchemaReload) {
       if (globals.consoleMode === CLI_CONSOLE_MODE) {
-        dispatch(loadMigrationStatus()); // don't call for server mode
+        dispatch(loadMigrationStatus());
       }
       dispatch(updateSchemaInfo());
     }
@@ -609,10 +609,9 @@ const makeMigrationCall = (
 
   dispatch({ type: MAKE_REQUEST });
   dispatch(showSuccessNotification(requestMsg));
-  dispatch(requestAction(url, options, REQUEST_SUCCESS, REQUEST_ERROR)).then(
-    onSuccess,
-    onError
-  );
+  return dispatch(
+    requestAction(url, options, REQUEST_SUCCESS, REQUEST_ERROR)
+  ).then(onSuccess, onError);
 };
 
 const getBulkColumnInfoFetchQuery = (schema, source) => {

--- a/console/src/components/Services/Data/Function/Permission/Permission.js
+++ b/console/src/components/Services/Data/Function/Permission/Permission.js
@@ -1,11 +1,10 @@
 import React from 'react';
-
 import Helmet from 'react-helmet';
-import CommonTabLayout from '../../../../Common/Layout/CommonTabLayout/CommonTabLayout';
 import { Link } from 'react-router';
 import { push } from 'react-router-redux';
 import { connect } from 'react-redux';
 
+import CommonTabLayout from '../../../../Common/Layout/CommonTabLayout/CommonTabLayout';
 import tabInfo from '../Modify/tabInfo';
 import globals from '../../../../../Globals';
 import { fetchCustomFunction } from '../customFunctionReducer';
@@ -22,6 +21,7 @@ import {
   getTablePermissionsRoute,
 } from '../../../../Common/utils/routesUtils';
 import { pageTitle } from '../Modify/ModifyCustomFunction';
+import styles from '../Modify/ModifyCustomFunction.scss';
 
 class Permission extends React.Component {
   constructor(props) {
@@ -51,7 +51,6 @@ class Permission extends React.Component {
     ]);
   }
   render() {
-    const styles = require('../Modify/ModifyCustomFunction.scss');
     const {
       functionSchema: schema,
       functionName,

--- a/console/src/components/Services/Data/Function/customFunctionReducer.js
+++ b/console/src/components/Services/Data/Function/customFunctionReducer.js
@@ -106,7 +106,7 @@ const deleteFunction = () => (dispatch, getState) => {
   const errorMsg = 'Deleting function failed';
 
   const customOnSuccess = () =>
-    dispatch(_push(getSchemaBaseRoute(currentSchema)));
+    dispatch(_push(getSchemaBaseRoute(currentSchema, source)));
   const customOnError = () => dispatch({ type: DELETE_CUSTOM_FUNCTION_FAIL });
 
   dispatch({ type: DELETING_CUSTOM_FUNCTION });
@@ -147,7 +147,7 @@ const unTrackCustomFunction = () => {
     const errorMsg = 'Delete custom function failed';
 
     const customOnSuccess = () => {
-      dispatch(_push(getSchemaBaseRoute(currentSchema)));
+      dispatch(_push(getSchemaBaseRoute(currentSchema, currentDataSource)));
       dispatch({ type: RESET });
       dispatch(exportMetadata());
     };

--- a/console/src/components/Services/Data/RawSQL/RawSQL.js
+++ b/console/src/components/Services/Data/RawSQL/RawSQL.js
@@ -66,6 +66,7 @@ const RawSQL = ({
   isTableTrackChecked,
   migrationMode,
   allSchemas,
+  currentSchema,
 }) => {
   const [statementTimeout, setStatementTimeout] = useState(
     Number(getLSItem(LS_KEYS.rawSqlStatementTimeout)) || 10
@@ -170,7 +171,13 @@ const RawSQL = ({
         });
 
         allObjectsTrackable = objects.every(object => {
-          const objectName = [object.schema, object.name].join('.');
+          let objectName;
+          if (object.schema) {
+            // the object's schema was explicitly specified
+            objectName = [object.schema, object.name].join('.');
+          } else {
+            objectName = [currentSchema, object.name].join('.');
+          }
 
           if (trackedObjectNames.includes(objectName)) {
             return false;

--- a/console/src/components/Services/Data/RawSQL/molecules/NotesSection.tsx
+++ b/console/src/components/Services/Data/RawSQL/molecules/NotesSection.tsx
@@ -15,6 +15,10 @@ const NotesSection = () => {
         Multiple SQL statements will be run as a transaction. i.e. if any
         statement fails, none of the statements will be applied.
       </li>
+      <li>
+        By default, if no schema is provided against the name of your entities,
+        we will be using the <code>public</code> schema.
+      </li>
     </ul>
   );
 };

--- a/console/src/components/Services/Data/TableCommon/TableHeader.js
+++ b/console/src/components/Services/Data/TableCommon/TableHeader.js
@@ -35,9 +35,6 @@ const TableHeader = ({
   const isTableType = dataSource.isTable(table);
 
   let countDisplay = '';
-  // if (exists(count)) {
-  //   countDisplay = `(${isCountEstimated ? '~' : '' }${getReadableNumber(count)})`;
-  // }
   if (exists(count) && !isCountEstimated) {
     countDisplay = `(${getReadableNumber(count)})`;
   }
@@ -53,11 +50,11 @@ const TableHeader = ({
     return [
       {
         title: 'Data',
-        url: '/data',
+        url: getSchemaBaseRoute(tableSchema, source),
       },
       {
         title: 'Schema',
-        url: '/data/schema/',
+        url: getSchemaBaseRoute(tableSchema, source),
       },
       {
         title: tableSchema,

--- a/console/src/components/Services/Data/TableModify/ModifyActions.js
+++ b/console/src/components/Services/Data/TableModify/ModifyActions.js
@@ -803,15 +803,14 @@ const changeTableName = (oldName, newName, isTable, tableType) => {
     const migrateUp = [getRunSqlQuery(upSql, source)];
     const migrateDown = [getRunSqlQuery(downSql, source)];
     // apply migrations
-    const migrationName =
-      `rename_${compositeName}_` + currentSchema + '_' + oldName;
+    const migrationName = `rename_${compositeName}_${currentSchema}_${oldName}`;
 
     const requestMsg = `Renaming ${property}...`;
     const successMsg = `Renaming ${property} successful`;
     const errorMsg = `Renaming ${property} failed`;
 
     const customOnSuccess = () => {
-      dispatch(_push(getSchemaBaseRoute(currentSchema))); // to avoid 404
+      dispatch(_push(getSchemaBaseRoute(currentSchema, source))); // to avoid 404
       dispatch(updateSchemaInfo()).then(() => {
         dispatch(
           _push(getTableModifyRoute(currentSchema, source, newName, isTable))
@@ -895,17 +894,15 @@ const deleteTableSql = tableName => {
 
     const migration = new Migration();
     migration.add(getRunSqlQuery(sqlDropTable, source));
-    // apply migrations
-    const migrationName = 'drop_table_' + currentSchema + '_' + tableName;
 
+    const migrationName = `drop_table_${currentSchema}_${tableName}`;
     const requestMsg = 'Deleting table...';
     const successMsg = 'Table deleted';
     const errorMsg = 'Deleting table failed';
 
     const customOnSuccess = () => {
       dispatch(updateSchemaInfo());
-
-      dispatch(_push('/data/'));
+      dispatch(_push(getSchemaBaseRoute(currentSchema, source)));
     };
 
     const customOnError = err => {
@@ -1051,7 +1048,7 @@ const deleteViewSql = (viewName, viewType) => {
     const errorMsg = `Deleting ${property} failed`;
 
     const customOnSuccess = () => {
-      dispatch(_push('/data/'));
+      dispatch(_push(getSchemaBaseRoute(currentSchema, source)));
     };
     const customOnError = () => {};
 

--- a/console/src/components/Services/Data/TablePermissions/Actions.js
+++ b/console/src/components/Services/Data/TablePermissions/Actions.js
@@ -223,7 +223,8 @@ const toggleAllFields = (permissions, allFields, fieldType) => {
   let allFieldsSelected = true;
 
   Object.keys(allFields).forEach(fType => {
-    const currSelected = permissions ? permissions[fType] : [];
+    const currSelected =
+      permissions && permissions[fType] ? permissions[fType] : [];
 
     const allSelected = currSelected.length === allFields[fType].length;
 

--- a/console/src/components/Services/Data/TablePermissions/Permissions.js
+++ b/console/src/components/Services/Data/TablePermissions/Permissions.js
@@ -419,8 +419,12 @@ class Permissions extends Component {
                 ) {
                   if (checkColumns && checkComputedFields) {
                     _permission = permissionsSymbols.partialAccess;
-
-                    if (tableSchema.columns && groupedComputedFields.scalar) {
+                    if (
+                      tableSchema.columns &&
+                      groupedComputedFields.scalar &&
+                      Object.keys(tableSchema.columns).length &&
+                      Object.keys(groupedComputedFields.scalar).length
+                    ) {
                       if (
                         !permissions.columns ||
                         !permissions.computed_fields
@@ -440,8 +444,6 @@ class Permissions extends Component {
                       if (isPermissionsSetForComputedFields(permissions)) {
                         _permission = permissionsSymbols.fullAccess;
                       }
-                    } else {
-                      _permission = permissionsSymbols.noAccess;
                     }
                   } else if (checkColumns) {
                     if (isPermissionsSetForColumns(permissions)) {

--- a/console/src/components/Services/Types/ServerIO.js
+++ b/console/src/components/Services/Types/ServerIO.js
@@ -33,7 +33,7 @@ export const setCustomGraphQLTypes = (types, successCb, errorCb) => (
 
   const migrationName = 'set_custom_types';
   const requestMsg = 'Setting custom types...';
-  const successMsg = 'Setting custom types successfull';
+  const successMsg = 'Setting custom types successful';
   const errorMsg = 'Setting custom types failed';
 
   const customOnSuccess = () => {


### PR DESCRIPTION
#### Done

- Correct icons to be displayed on Table permissions page
![image](https://user-images.githubusercontent.com/6604943/98401726-28fb4c00-208c-11eb-839a-d23a9e3f2e05.png)

- rename table name doesn't work (only some routing issues here)

- added an `asyncSeries` method to ensure that when functions/tables/views are being tracked from RawSQL, it happens in series.

#### TODO

- tracking table on a different schema (@beerose , so when a user is on a different schema other than the public schema, they shouldn't be expecting for the SQL statement to be executed on the same schema right?) 

 - custom functions un-tracking (possible server issue again here, because the response says that the custom function could not be located in the schema cache) (see below for the request and the error) 

**Update:** this seems to be only working for the `default` data source and not on any other data source

#### Issues

- possible bug while trying to alter column related details from the console. So running something like this request:
```json
{
    "type": "bulk",
    "source": "pg-11",
    "args": [{
        "type": "run_sql",
        "args": {
            "sql": "ALTER TABLE public.new_tab alter column first_name type text;"
        }
    }, {
        "type": "run_sql",
        "args": {
            "sql": "COMMENT on column public.new_tab.last_name is 'column comment here'"
        }
    }]
}
```

 used while modifying the comment or any other detail about a particular column. The server never responds it's just stuck in a loop or some locks aren't released. So yeah, that is causing some issues. 

Update: Upon some digging, I see that it's the `comment` statement that is causing some issues.

- Custom Function un-tracking request 

```json
{
            "type": "pg_untrack_function",
            "args": {
                "name": "search_articles",
                "schema": "public",
                "source": "pg-11"
            }
        }
```

Response : 
```json
{
    "path": "$[0]",
    "error": "function not found in cache \"search_articles\"",
    "code": "not-exists"
}
```
